### PR TITLE
Fix short name for Tirol

### DIFF
--- a/src/at/subdivisions.csv
+++ b/src/at/subdivisions.csv
@@ -5,6 +5,6 @@ AT;AT-3;NÖ;DE Niederösterreich,EN Lower Austria;DE
 AT;AT-4;OÖ;DE Oberösterreich,EN Upper Austria;DE
 AT;AT-5;SB;DE Salzburg,EN Salzburg;DE
 AT;AT-6;SM;DE Steiermark,EN Styria;DE
-AT;AT-7;TO;DE Tirol,EN Tyrol;DE
+AT;AT-7;TI;DE Tirol,EN Tyrol;DE
 AT;AT-8;VA;DE Vorarlberg,EN Vorarlberg;DE
 AT;AT-9;WI;DE Wien,EN Vienna;DE


### PR DESCRIPTION
The short name here does not match the short name used in the holidays folder