### PR TITLE
add: Portuguese subdivisions and public holidays (national and district level)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repo aggregates and stores freely accessible calendar data on the following
 + Monaco (public holidays and school holidays from 2020)
 + Netherlands (public holidays and school holidays from 2020)
 + Poland (public holidays and school holidays from 2020)
++ Portugal (national and district public holidays from 2020)
 + San Marino (public holidays and school holidays from 2020)
 + Slovakia (public holidays and school holidays from 2020)
 + Slovenia (public holidays and school holidays from 2020)
@@ -287,6 +288,13 @@ Public holidays:
 School holidays:
 
 + Ministerstwo Edukacji i Nauki: [Kalendarz roku szkolnego](https://www.gov.pl/web/edukacja-i-nauka/kalendarz-roku-szkolnego)
+
+### Portugal
+
+Public holidays:
+
++ [Código do Trabalho - CT - Artigo 234.º / Lei n.º 7/2009](https://diariodarepublica.pt/dr/legislacao-consolidada/lei/2009-34546475-73982045)
++ [Decreto Legislativo Regional 18/2002/M, de 8 de Novembro](https://dre.tretas.org/dre/157858/decreto-legislativo-regional-18-2002-M-de-8-de-novembro)
 
 ### San Marino
 

--- a/src/countries.csv
+++ b/src/countries.csv
@@ -18,6 +18,7 @@ MC;EN Monaco,FR Monaco,DE Monaco;FR
 MT;EN Malta,MT Malta,DE Malta;MT,EN
 NL;EN Netherlands (the),NL Nederland,DE Niederlande;NL
 PL;EN Poland,PL Polska,DE Polen;PL
+PT;EN Portugal,PT Portugal,DE Portugal;PT
 SI;EN Slovenia,SL Slovenija,DE Slowenien;SL
 SK;EN Slovakia,SK Slovensko,DE Slowakei;SK
 SM;EN San Marino,IT San Marino,DE San Marino;IT

--- a/src/languages.csv
+++ b/src/languages.csv
@@ -15,6 +15,7 @@ LV;EN Latvian,LV Latviešu,DE Lettisch
 MT;EN Maltese,MT Malti,DE Maltesisch
 NL;EN Dutch,NL Nederlands,DE Niederländisch
 PL;EN Polish,PL Polska,DE Polnisch
+PT;EN Portuguese,PT Português,DE Portugiesisch
 RM;EN Romansh,RM Rumantsch,DE Rätoromanisch
 SL;EN Slovenian,SL Slovenski,DE Slowenisch
 SK;EN Slovak,SK Slovenský,DE Slowakisch

--- a/src/pt/holidays/holidays.public.csv
+++ b/src/pt/holidays/holidays.public.csv
@@ -1,0 +1,199 @@
+﻿Id;Country;StartDate;EndDate;Type;Name;Subdivisions
+e3986a7a-e268-4c45-a533-8e90298ac3b8;PT;2020-01-01;;Public;PT Ano Novo,EN New Year's Day,DE Neujahr;
+232b555a-b5b1-43ca-82d9-5497a55afe96;PT;2020-04-10;;Public;PT Sexta-feira Santa,EN Good Friday,DE Karfreitag;
+41f1f1f5-347b-4f15-8e76-7767b9cd3556;PT;2020-04-12;;Public;PT Domingo de Páscoa,EN Easter Sunday,DE Ostersonntag;
+179182e9-c28e-4e9e-904b-e43aa8e1c07d;PT;2020-04-25;;Public;PT Dia da Liberdade,EN Liberty Day,DE Tag der Freiheit;
+b5f0e04c-89e5-4de0-9295-d5fcf7432014;PT;2020-05-01;;Public;PT Dia do Trabalhador,EN Labor Day,DE Tag der Arbeit;
+30bce103-1466-4c82-8762-f5a3fa386b13;PT;2020-06-01;;Public;PT Dia dos Açores,EN Azores Day,DE Tag der Azoren;AC
+c6421faa-a5fc-4217-92d9-3a0060a3aca0;PT;2020-06-10;;Public;PT Dia de Portugal / de Camões e das Comunidades Portuguesas,EN Portugal Day,DE Portugiesischer Nationalfeiertag;
+4c689ed3-6fc1-4635-949f-e26b28d0e644;PT;2020-06-11;;Public;PT Corpo de Deus,EN Corpus Christi,DE Fronleichnam;
+4fdb4132-674a-4f64-8de8-972c9e2d1417;PT;2020-06-13;;Public;PT Dia de Santo António,EN Feast of St. Anthony,DE Tag des Heiligen Antonius;LI
+ad87798c-9753-4f40-8f12-741266c1a084;PT;2020-06-24;;Public;PT Dia de São João Baptista,EN Saint John's Day,DE Johannistag;BRG,ALM,PRT
+04bb2d47-64fe-4a77-ad39-baad9cd6d9d7;PT;2020-07-01;;Public;PT Dia da Madeira,EN Madeira Day,DE Madeira-Tag;MA
+7dda4830-316f-4c6a-8d60-80daaee73f94;PT;2020-08-15;;Public;PT Assunção de Nossa Senhora,EN Assumption Day,DE Mariä Himmelfahrt;
+2880a166-354e-4afa-9a5a-9ea730a40c4d;PT;2020-10-05;;Public;PT Implantação da República,EN Republic Day,DE Tag der Republik;
+6ce9752d-4e20-4c03-af8d-cd9d27f04dc7;PT;2020-11-01;;Public;PT Todos-os-Santos,EN All Saints' Day,DE Allerheiligen;
+2ad9ae2c-0c26-47d6-915c-314a79151fb3;PT;2020-12-01;;Public;PT Restauração da Independência,EN Independence Day,DE Unabhängigkeitstag;
+bad92cde-513b-4dd6-be94-066faac20240;PT;2020-12-08;;Public;PT Imaculada Conceição,EN Immaculate Conception Day,DE Tag der Unbefleckten Empfängnis;
+2e15a433-2d18-4a4e-8b74-b81d877704be;PT;2020-12-25;;Public;PT Natal,EN Christmas,DE Weihnachten;
+879f6247-ff7a-4d9f-97a4-785534cca2f4;PT;2020-12-26;;Public;PT Primeira Oitava,EN Boxing Day,DE 2. Weihnachtsfeiertag;MA
+1ff96d15-77c8-41f8-b628-5090d03030b3;PT;2021-01-01;;Public;PT Ano Novo,EN New Year's Day,DE Neujahr;
+a1873c0c-17ef-42b7-8ad4-1e0d1dacedb4;PT;2021-04-02;;Public;PT Sexta-feira Santa,EN Good Friday,DE Karfreitag;
+bae061f8-b744-4ab8-b6c8-5e8de0f2f1e4;PT;2021-04-04;;Public;PT Domingo de Páscoa,EN Easter Sunday,DE Ostersonntag;
+f4486ef1-68e8-42a0-98f0-9fc783e07ba0;PT;2021-04-25;;Public;PT Dia da Liberdade,EN Liberty Day,DE Tag der Freiheit;
+f85ededc-62bb-4cda-84a1-dd540479f8cb;PT;2021-05-01;;Public;PT Dia do Trabalhador,EN Labor Day,DE Tag der Arbeit;
+121d1db6-37ae-4961-9458-76dd1162a62b;PT;2021-05-24;;Public;PT Dia dos Açores,EN Azores Day,DE Tag der Azoren;AC
+3beab8dd-60a5-4a87-aa01-89b8da1a2ec2;PT;2021-06-03;;Public;PT Corpo de Deus,EN Corpus Christi,DE Fronleichnam;
+9dd8ba37-a5f0-4cf0-afb1-3260db282d29;PT;2021-06-10;;Public;PT Dia de Portugal / de Camões e das Comunidades Portuguesas,EN Portugal Day,DE Portugiesischer Nationalfeiertag;
+22ec14aa-dfd8-4cb8-acbf-32844efa97d8;PT;2021-06-13;;Public;PT Dia de Santo António,EN Feast of St. Anthony,DE Tag des Heiligen Antonius;LI
+0290cf76-82ca-4d51-9671-d2d0238591b2;PT;2021-06-24;;Public;PT Dia de São João Baptista,EN Saint John's Day,DE Johannistag;BRG,ALM,PRT
+a0319dad-a38b-49e4-9625-08fef7387030;PT;2021-07-01;;Public;PT Dia da Madeira,EN Madeira Day,DE Madeira-Tag;MA
+077ddf49-9e42-4423-acb1-0bf910ffce2c;PT;2021-08-15;;Public;PT Assunção de Nossa Senhora,EN Assumption Day,DE Mariä Himmelfahrt;
+e475d88c-652d-4956-86a5-1171f0a4bfa5;PT;2021-10-05;;Public;PT Implantação da República,EN Republic Day,DE Tag der Republik;
+d15724a9-a318-4414-b0f2-d26775167b09;PT;2021-11-01;;Public;PT Todos-os-Santos,EN All Saints' Day,DE Allerheiligen;
+5b15f932-585b-4789-aeeb-7a3299f83e67;PT;2021-12-01;;Public;PT Restauração da Independência,EN Independence Day,DE Unabhängigkeitstag;
+4955591e-0de2-4947-9819-4bb885f69823;PT;2021-12-08;;Public;PT Imaculada Conceição,EN Immaculate Conception Day,DE Tag der Unbefleckten Empfängnis;
+829b63db-047e-4e52-aaf8-04e910f7d980;PT;2021-12-25;;Public;PT Natal,EN Christmas,DE Weihnachten;
+37da7511-aff9-4b2c-8699-1f99c3964bed;PT;2021-12-26;;Public;PT Primeira Oitava,EN Boxing Day,DE 2. Weihnachtsfeiertag;MA
+9e062e70-43e1-4650-a92e-b205930b4588;PT;2022-01-01;;Public;PT Ano Novo,EN New Year's Day,DE Neujahr;
+28f32a5e-555a-43db-aefc-b54e4954f8bc;PT;2022-04-15;;Public;PT Sexta-feira Santa,EN Good Friday,DE Karfreitag;
+a1696a2d-472e-481c-ad9f-d59c68290010;PT;2022-04-17;;Public;PT Domingo de Páscoa,EN Easter Sunday,DE Ostersonntag;
+80decf50-05af-42c4-9d3d-8ff05ac9aa62;PT;2022-04-25;;Public;PT Dia da Liberdade,EN Liberty Day,DE Tag der Freiheit;
+0fc3a5db-9013-4c71-b15b-a23d873b91db;PT;2022-05-01;;Public;PT Dia do Trabalhador,EN Labor Day,DE Tag der Arbeit;
+b50899e9-1d21-4723-9e59-a1378345757f;PT;2022-06-06;;Public;PT Dia dos Açores,EN Azores Day,DE Tag der Azoren;AC
+f2ee4118-becf-4922-a6cc-9039790556d0;PT;2022-06-10;;Public;PT Dia de Portugal / de Camões e das Comunidades Portuguesas,EN Portugal Day,DE Portugiesischer Nationalfeiertag;
+03dc02c7-6087-4aad-9a8c-33869c413700;PT;2022-06-16;;Public;PT Corpo de Deus,EN Corpus Christi,DE Fronleichnam;
+db363107-a013-4c79-900b-0f25ad108abd;PT;2022-06-13;;Public;PT Dia de Santo António,EN Feast of St. Anthony,DE Tag des Heiligen Antonius;LI
+17992356-357c-4c07-82f3-b732651568d3;PT;2022-06-24;;Public;PT Dia de São João Baptista,EN Saint John's Day,DE Johannistag;BRG,ALM,PRT
+3578c8f4-cbc5-43a8-8c19-10b702622a82;PT;2022-07-01;;Public;PT Dia da Madeira,EN Madeira Day,DE Madeira-Tag;MA
+7e4ad745-63e2-4358-9366-b2937fbd548d;PT;2022-08-15;;Public;PT Assunção de Nossa Senhora,EN Assumption Day,DE Mariä Himmelfahrt;
+6f9283b8-af6a-4c75-b29b-8a8d5dfb8858;PT;2022-10-05;;Public;PT Implantação da República,EN Republic Day,DE Tag der Republik;
+d3355c06-792b-46ab-bac1-07549e9ff388;PT;2022-11-01;;Public;PT Todos-os-Santos,EN All Saints' Day,DE Allerheiligen;
+0755caa3-548a-4c92-b823-25c479868bbc;PT;2022-12-01;;Public;PT Restauração da Independência,EN Independence Day,DE Unabhängigkeitstag;
+7a27ff93-e41d-449a-95e3-87429acf5c59;PT;2022-12-08;;Public;PT Imaculada Conceição,EN Immaculate Conception Day,DE Tag der Unbefleckten Empfängnis;
+c7bac23b-09dc-4ee3-97a2-75aeeb5481c6;PT;2022-12-25;;Public;PT Natal,EN Christmas,DE Weihnachten;
+a5b6ebdf-1da2-4c67-bd15-b155c6a0e4af;PT;2022-12-26;;Public;PT Primeira Oitava,EN Boxing Day,DE 2. Weihnachtsfeiertag;MA
+dfc38a9f-2df0-4ed9-8066-4326d5d25d72;PT;2023-01-01;;Public;PT Ano Novo,EN New Year's Day,DE Neujahr;
+5c2604d7-eebb-4cb6-a837-d4cab6370549;PT;2023-04-07;;Public;PT Sexta-feira Santa,EN Good Friday,DE Karfreitag;
+b5651c32-ca61-4b06-a2f0-8f4ad35493bf;PT;2023-04-09;;Public;PT Domingo de Páscoa,EN Easter Sunday,DE Ostersonntag;
+b9a7ba4b-7083-4dd9-8d11-6575474f7902;PT;2023-04-25;;Public;PT Dia da Liberdade,EN Liberty Day,DE Tag der Freiheit;
+d37ad5d1-d5f7-4944-be80-bf4a65788627;PT;2023-05-01;;Public;PT Dia do Trabalhador,EN Labor Day,DE Tag der Arbeit;
+76003d47-e671-448a-b6e6-b55f8e32300f;PT;2023-05-29;;Public;PT Dia dos Açores,EN Azores Day,DE Tag der Azoren;AC
+ffb4c908-ff0e-445f-bec4-70d96202e607;PT;2023-06-08;;Public;PT Corpo de Deus,EN Corpus Christi,DE Fronleichnam;
+7dda0724-ed25-49c0-8e9a-02bea58b9ed4;PT;2023-06-10;;Public;PT Dia de Portugal / de Camões e das Comunidades Portuguesas,EN Portugal Day,DE Portugiesischer Nationalfeiertag;
+6248ae26-c2f9-40d7-ad08-1a25839a1607;PT;2023-06-13;;Public;PT Dia de Santo António,EN Feast of St. Anthony,DE Tag des Heiligen Antonius;LI
+b15c7b1b-b83e-42c5-b0fb-386324debed2;PT;2023-06-24;;Public;PT Dia de São João Baptista,EN Saint John's Day,DE Johannistag;BRG,ALM,PRT
+59cbeb31-f9f4-48ed-9d3a-4df3f22ffe48;PT;2023-07-01;;Public;PT Dia da Madeira,EN Madeira Day,DE Madeira-Tag;MA
+b787e6af-e80f-4ad4-8ee1-a0f0476ad917;PT;2023-08-15;;Public;PT Assunção de Nossa Senhora,EN Assumption Day,DE Mariä Himmelfahrt;
+81622cc0-8dc7-4155-a4e5-c634a5eca37c;PT;2023-10-05;;Public;PT Implantação da República,EN Republic Day,DE Tag der Republik;
+ad5abffa-9b24-4b7d-a7cf-2eb2b852a55d;PT;2023-11-01;;Public;PT Todos-os-Santos,EN All Saints' Day,DE Allerheiligen;
+b38d9eda-11e7-4272-b380-647833b63182;PT;2023-12-01;;Public;PT Restauração da Independência,EN Independence Day,DE Unabhängigkeitstag;
+748a7466-1732-474f-be5c-52342518aaed;PT;2023-12-08;;Public;PT Imaculada Conceição,EN Immaculate Conception Day,DE Tag der Unbefleckten Empfängnis;
+855721f7-cad9-4a71-90eb-6382d9b6e6ff;PT;2023-12-25;;Public;PT Natal,EN Christmas,DE Weihnachten;
+f0f2e188-ba32-41d6-bcd7-3386560d7a0e;PT;2023-12-26;;Public;PT Primeira Oitava,EN Boxing Day,DE 2. Weihnachtsfeiertag;MA
+d905b3a0-b161-40f5-809a-9ce443ea6ef0;PT;2024-01-01;;Public;PT Ano Novo,EN New Year's Day,DE Neujahr;
+f3b0fe59-b37b-41f1-9ce5-b3619cd976cb;PT;2024-03-29;;Public;PT Sexta-feira Santa,EN Good Friday,DE Karfreitag;
+daeec60a-4af3-4b8b-9a57-fec3fbec6915;PT;2024-03-31;;Public;PT Domingo de Páscoa,EN Easter Sunday,DE Ostersonntag;
+546d7414-ee0b-415e-8386-205946db58b7;PT;2024-04-25;;Public;PT Dia da Liberdade,EN Liberty Day,DE Tag der Freiheit;
+a3e263b1-4263-4727-9dfe-d4d2536ad71c;PT;2024-05-01;;Public;PT Dia do Trabalhador,EN Labor Day,DE Tag der Arbeit;
+c512b803-8b85-4d81-97ae-78a417cafe8b;PT;2024-05-20;;Public;PT Dia dos Açores,EN Azores Day,DE Tag der Azoren;AC
+08388d6d-e076-48f6-9068-e95cbe53f751;PT;2024-05-30;;Public;PT Corpo de Deus,EN Corpus Christi,DE Fronleichnam;
+84e34896-1c0e-4056-b6e1-36012e8c1d93;PT;2024-06-10;;Public;PT Dia de Portugal / de Camões e das Comunidades Portuguesas,EN Portugal Day,DE Portugiesischer Nationalfeiertag;
+7ffa41bb-850b-4a31-ac51-da26210e3daa;PT;2024-06-13;;Public;PT Dia de Santo António,EN Feast of St. Anthony,DE Tag des Heiligen Antonius;LI
+41053b82-bf4e-4b89-80ce-a9e36f066fd8;PT;2024-06-24;;Public;PT Dia de São João Baptista,EN Saint John's Day,DE Johannistag;BRG,ALM,PRT
+f29c7a43-2cfd-4171-8518-b51abf0d72d5;PT;2024-07-01;;Public;PT Dia da Madeira,EN Madeira Day,DE Madeira-Tag;MA
+ac3c22a4-41f6-4a53-a580-7d811e5be3eb;PT;2024-08-15;;Public;PT Assunção de Nossa Senhora,EN Assumption Day,DE Mariä Himmelfahrt;
+6032ad82-06cc-4921-b111-f5838cc59f3c;PT;2024-10-05;;Public;PT Implantação da República,EN Republic Day,DE Tag der Republik;
+840cb5bb-d1e4-44b1-9cb9-63f380b77cb4;PT;2024-11-01;;Public;PT Todos-os-Santos,EN All Saints' Day,DE Allerheiligen;
+15f70a18-6e47-488a-aaee-9322aebe840f;PT;2024-12-01;;Public;PT Restauração da Independência,EN Independence Day,DE Unabhängigkeitstag;
+97f632f8-7d5a-489e-9111-66bc6e1fab32;PT;2024-12-08;;Public;PT Imaculada Conceição,EN Immaculate Conception Day,DE Tag der Unbefleckten Empfängnis;
+145ebb2e-3375-4f0d-bc6c-cee998871dfe;PT;2024-12-25;;Public;PT Natal,EN Christmas,DE Weihnachten;
+9786b198-eb5f-4e74-b87a-b9e0c3dd4240;PT;2024-12-26;;Public;PT Primeira Oitava,EN Boxing Day,DE 2. Weihnachtsfeiertag;MA
+556f819f-56e2-498d-9a1e-599017e85f8a;PT;2025-01-01;;Public;PT Ano Novo,EN New Year's Day,DE Neujahr;
+6dc9e537-28fc-43f1-b739-1c831c6e2f34;PT;2025-04-07;;Public;PT Sexta-feira Santa,EN Good Friday,DE Karfreitag;
+40b8df7c-98b5-4333-8449-1ef5a81a586b;PT;2025-04-25;;Public;PT Dia da Liberdade,EN Liberty Day,DE Tag der Freiheit;
+035df30c-4f45-4e47-9205-75e2b5dcf802;PT;2025-04-09;;Public;PT Domingo de Páscoa,EN Easter Sunday,DE Ostersonntag;
+37b51c8a-de34-4d38-898c-2e9504474fc8;PT;2025-05-01;;Public;PT Dia do Trabalhador,EN Labor Day,DE Tag der Arbeit;
+4008d91f-4308-41c8-bf50-927d709ba511;PT;2025-06-08;;Public;PT Corpo de Deus,EN Corpus Christi,DE Fronleichnam;
+7ab47b64-8607-42d8-b121-036e3d0c5be3;PT;2025-06-09;;Public;PT Dia dos Açores,EN Azores Day,DE Tag der Azoren;AC
+8b912098-6f90-48e0-9971-ee0039744575;PT;2025-06-10;;Public;PT Dia de Portugal / de Camões e das Comunidades Portuguesas,EN Portugal Day,DE Portugiesischer Nationalfeiertag;
+d553f5f0-7ce8-432a-a76e-f409fb607b4b;PT;2025-06-13;;Public;PT Dia de Santo António,EN Feast of St. Anthony,DE Tag des Heiligen Antonius;LI
+a816f524-8c07-4c6a-82e2-1055ce534081;PT;2025-06-24;;Public;PT Dia de São João Baptista,EN Saint John's Day,DE Johannistag;BRG,ALM,PRT
+11cf5a34-f107-497b-a86e-d729caf2c060;PT;2025-07-01;;Public;PT Dia da Madeira,EN Madeira Day,DE Madeira-Tag;MA
+1b06541b-f2c3-46ea-a897-046652f0ee82;PT;2025-08-15;;Public;PT Assunção de Nossa Senhora,EN Assumption Day,DE Mariä Himmelfahrt;
+7f92fd24-535d-404d-a8b7-a363f632eb1c;PT;2025-10-05;;Public;PT Implantação da República,EN Republic Day,DE Tag der Republik;
+2442451c-3186-48b6-ba4e-fc52d8282fa9;PT;2025-11-01;;Public;PT Todos-os-Santos,EN All Saints' Day,DE Allerheiligen;
+246eb060-45fb-4069-9afd-dbef3c1f4758;PT;2025-12-01;;Public;PT Restauração da Independência,EN Independence Day,DE Unabhängigkeitstag;
+3d0ecf15-beb2-4a44-8051-71f428fe3684;PT;2025-12-08;;Public;PT Imaculada Conceição,EN Immaculate Conception Day,DE Tag der Unbefleckten Empfängnis;
+9824adc5-fbf0-4800-ab29-cf8cdbef7fca;PT;2025-12-25;;Public;PT Natal,EN Christmas,DE Weihnachten;
+5be2f7db-6930-4f90-b89c-d03309e5cd3b;PT;2025-12-26;;Public;PT Primeira Oitava,EN Boxing Day,DE 2. Weihnachtsfeiertag;MA
+eb86e163-1ed7-4b16-aab6-dee82f79d51b;PT;2026-01-01;;Public;PT Ano Novo,EN New Year's Day,DE Neujahr;
+b795d6b9-c230-4054-bbc7-0b4bbbae1d71;PT;2026-04-03;;Public;PT Sexta-feira Santa,EN Good Friday,DE Karfreitag;
+af6096ef-ba9c-40d7-ab0f-62e8e21f85c9;PT;2026-04-05;;Public;PT Domingo de Páscoa,EN Easter Sunday,DE Ostersonntag;
+f30befde-c2c5-4bc8-ba70-492cbcbb7a78;PT;2026-04-25;;Public;PT Dia da Liberdade,EN Liberty Day,DE Tag der Freiheit;
+d931fd2b-f291-4547-8712-afbb83367bf1;PT;2026-05-01;;Public;PT Dia do Trabalhador,EN Labor Day,DE Tag der Arbeit;
+5ddfcc52-ea06-4a80-9a05-4fa21d86b4fb;PT;2026-05-25;;Public;PT Dia dos Açores,EN Azores Day,DE Tag der Azoren;AC
+abc5571a-b6b8-40aa-b166-bb57d5b562e4;PT;2026-06-04;;Public;PT Corpo de Deus,EN Corpus Christi,DE Fronleichnam;
+41bc2134-572f-4a30-9a1f-afce15e7c236;PT;2026-06-10;;Public;PT Dia de Portugal / de Camões e das Comunidades Portuguesas,EN Portugal Day,DE Portugiesischer Nationalfeiertag;
+c9818d32-cc67-4cfa-8ed2-425260b70e5a;PT;2026-06-13;;Public;PT Dia de Santo António,EN Feast of St. Anthony,DE Tag des Heiligen Antonius;LI
+4823c140-c30a-497c-a64b-f41e12387c3b;PT;2026-06-24;;Public;PT Dia de São João Baptista,EN Saint John's Day,DE Johannistag;BRG,ALM,PRT
+cc20ad6d-b172-4f23-a03d-a2e516e8f054;PT;2026-07-01;;Public;PT Dia da Madeira,EN Madeira Day,DE Madeira-Tag;MA
+f6ead66e-408e-48a2-8441-9207cf6b9361;PT;2026-08-15;;Public;PT Assunção de Nossa Senhora,EN Assumption Day,DE Mariä Himmelfahrt;
+da1960fa-83a9-4299-8a74-fbd8cde79cb1;PT;2026-10-05;;Public;PT Implantação da República,EN Republic Day,DE Tag der Republik;
+94af43a6-3d3a-46bf-9442-07b2069bb5cf;PT;2026-11-01;;Public;PT Todos-os-Santos,EN All Saints' Day,DE Allerheiligen;
+5e5d815d-bfec-4b19-9263-25dd8a5a1cf3;PT;2026-12-01;;Public;PT Restauração da Independência,EN Independence Day,DE Unabhängigkeitstag;
+f1fe4a60-cc2d-4072-bbee-82d186a0973f;PT;2026-12-08;;Public;PT Imaculada Conceição,EN Immaculate Conception Day,DE Tag der Unbefleckten Empfängnis;
+eb3e78ec-59bd-4f81-beb5-c3a492ef53d7;PT;2026-12-25;;Public;PT Natal,EN Christmas,DE Weihnachten;
+4f5d1318-d085-440e-9acd-3422c0c3659f;PT;2026-12-26;;Public;PT Primeira Oitava,EN Boxing Day,DE 2. Weihnachtsfeiertag;MA
+d3839e66-4c07-4a8d-a2be-7f881686b8f6;PT;2027-01-01;;Public;PT Ano Novo,EN New Year's Day,DE Neujahr;
+09f7e12b-281c-4f96-b474-f7abc86cef29;PT;2027-03-26;;Public;PT Sexta-feira Santa,EN Good Friday,DE Karfreitag;
+b0c4c282-a1d5-422e-8c51-b99de91f34fc;PT;2027-03-28;;Public;PT Domingo de Páscoa,EN Easter Sunday,DE Ostersonntag;
+54d09fa1-3e92-415e-bcdc-dc4babfa9d38;PT;2027-04-25;;Public;PT Dia da Liberdade,EN Liberty Day,DE Tag der Freiheit;
+a8ef5d37-5ba9-433e-9690-a04cea94ed4d;PT;2027-05-01;;Public;PT Dia do Trabalhador,EN Labor Day,DE Tag der Arbeit;
+bccb85ba-6a57-4931-83b4-97db565cd242;PT;2027-05-17;;Public;PT Dia dos Açores,EN Azores Day,DE Tag der Azoren;AC
+6665c22d-d2f6-4fd3-84fd-4e1de8795bdf;PT;2027-05-27;;Public;PT Corpo de Deus,EN Corpus Christi,DE Fronleichnam;
+2898f393-5333-4e6f-9600-1e77475aa9d9;PT;2027-06-10;;Public;PT Dia de Portugal / de Camões e das Comunidades Portuguesas,EN Portugal Day,DE Portugiesischer Nationalfeiertag;
+dee826e9-9c1e-4d70-ac47-a558459eb17f;PT;2027-06-13;;Public;PT Dia de Santo António,EN Feast of St. Anthony,DE Tag des Heiligen Antonius;LI
+06769d67-b29e-4326-823c-4894479cd305;PT;2027-06-24;;Public;PT Dia de São João Baptista,EN Saint John's Day,DE Johannistag;BRG,ALM,PRT
+86bc610b-ece6-4136-b353-9e55966bebb9;PT;2027-07-01;;Public;PT Dia da Madeira,EN Madeira Day,DE Madeira-Tag;MA
+1ea615b3-ca25-4024-aa8b-18a4024435db;PT;2027-08-15;;Public;PT Assunção de Nossa Senhora,EN Assumption Day,DE Mariä Himmelfahrt;
+a4ff132f-3df3-40f9-837e-7714218495f8;PT;2027-10-05;;Public;PT Implantação da República,EN Republic Day,DE Tag der Republik;
+8c2a0306-edf2-4df8-a96f-52fab19dfac3;PT;2027-11-01;;Public;PT Todos-os-Santos,EN All Saints' Day,DE Allerheiligen;
+0dd4a150-a341-4418-a5be-530c8f64fb9a;PT;2027-12-01;;Public;PT Restauração da Independência,EN Independence Day,DE Unabhängigkeitstag;
+2ad3c27d-1335-4071-bbe7-88ea85d79194;PT;2027-12-08;;Public;PT Imaculada Conceição,EN Immaculate Conception Day,DE Tag der Unbefleckten Empfängnis;
+bd912014-41c5-46b2-bf24-939ea00308bd;PT;2027-12-25;;Public;PT Natal,EN Christmas,DE Weihnachten;
+8ef49255-fa7d-418c-9f94-37fe1521ab69;PT;2027-12-26;;Public;PT Primeira Oitava,EN Boxing Day,DE 2. Weihnachtsfeiertag;MA
+ef08ccea-55b2-4b7c-b774-5dcfdafe60d5;PT;2028-01-01;;Public;PT Ano Novo,EN New Year's Day,DE Neujahr;
+565a08fa-8d42-477f-806d-192986e1680c;PT;2028-04-14;;Public;PT Sexta-feira Santa,EN Good Friday,DE Karfreitag;
+826ec276-9992-4667-b7e2-a4bfb94cea5a;PT;2028-04-16;;Public;PT Domingo de Páscoa,EN Easter Sunday,DE Ostersonntag;
+b1d7631d-4560-4d59-97cd-ba84f78fecb4;PT;2028-04-25;;Public;PT Dia da Liberdade,EN Liberty Day,DE Tag der Freiheit;
+b55871ca-f7ea-4daa-b0c3-dca55881ff92;PT;2028-06-05;;Public;PT Dia dos Açores,EN Azores Day,DE Tag der Azoren;AC
+6646d25a-7181-45ba-8411-1d4fbaba3176;PT;2028-06-15;;Public;PT Corpo de Deus,EN Corpus Christi,DE Fronleichnam;
+b971aeea-e7ce-441b-8380-d83851cf8ab7;PT;2028-06-13;;Public;PT Dia de Santo António,EN Feast of St. Anthony,DE Tag des Heiligen Antonius;LI
+af63d331-514a-4180-b865-76acb003b6c8;PT;2028-06-24;;Public;PT Dia de São João Baptista,EN Saint John's Day,DE Johannistag;BRG,ALM,PRT
+ba28d620-8b13-414c-86ba-6b3e75004d46;PT;2028-07-01;;Public;PT Dia da Madeira,EN Madeira Day,DE Madeira-Tag;MA
+06b408b6-1f5a-4294-a48b-4bcf2a86dee8;PT;2028-05-01;;Public;PT Dia do Trabalhador,EN Labor Day,DE Tag der Arbeit;
+70dbfb77-c4c4-4da5-8305-bfcfe4bc4b1e;PT;2028-06-10;;Public;PT Dia de Portugal / de Camões e das Comunidades Portuguesas,EN Portugal Day,DE Portugiesischer Nationalfeiertag;
+a2db8556-e005-46ba-b80a-3e92dcc31c11;PT;2028-08-15;;Public;PT Assunção de Nossa Senhora,EN Assumption Day,DE Mariä Himmelfahrt;
+722d9138-73ce-4c2f-923b-5e7eab782f38;PT;2028-10-05;;Public;PT Implantação da República,EN Republic Day,DE Tag der Republik;
+b3e6c322-008e-43ba-b326-a0bdc8886e24;PT;2028-11-01;;Public;PT Todos-os-Santos,EN All Saints' Day,DE Allerheiligen;
+2692d716-bd0e-485c-bb3b-0b3b2df88ce8;PT;2028-12-01;;Public;PT Restauração da Independência,EN Independence Day,DE Unabhängigkeitstag;
+8ad44935-7776-4292-8818-720a9599c047;PT;2028-12-08;;Public;PT Imaculada Conceição,EN Immaculate Conception Day,DE Tag der Unbefleckten Empfängnis;
+4f50e5b0-c057-4ef7-8eb8-7094c5ba7c93;PT;2028-12-25;;Public;PT Natal,EN Christmas,DE Weihnachten;
+c0a0e24d-598f-4af7-9eeb-7454900c9c99;PT;2028-12-26;;Public;PT Primeira Oitava,EN Boxing Day,DE 2. Weihnachtsfeiertag;MA
+4d310f67-910f-4500-85bb-26da045cd5e5;PT;2029-01-01;;Public;PT Ano Novo,EN New Year's Day,DE Neujahr;
+f24c2854-fbbc-4593-9769-a6838df9d79a;PT;2029-03-30;;Public;PT Sexta-feira Santa,EN Good Friday,DE Karfreitag;
+c64e2e61-7328-4c96-838f-e45fa22de07f;PT;2029-04-01;;Public;PT Domingo de Páscoa,EN Easter Sunday,DE Ostersonntag;
+cf69af4e-63b8-40ee-8420-d7990cd7932e;PT;2029-04-25;;Public;PT Dia da Liberdade,EN Liberty Day,DE Tag der Freiheit;
+f71637b5-b28f-4747-b05d-1b5b7b6d75a0;PT;2029-05-01;;Public;PT Dia do Trabalhador,EN Labor Day,DE Tag der Arbeit;
+a305b4c7-7a07-41fa-803d-c8ad377edb7c;PT;2029-05-21;;Public;PT Dia dos Açores,EN Azores Day,DE Tag der Azoren;AC
+9fbf43ce-6a1a-4e8e-9e6a-f5f29d37c649;PT;2029-05-31;;Public;PT Corpo de Deus,EN Corpus Christi,DE Fronleichnam;
+f4c795c1-a620-4553-ba39-a434c3840270;PT;2029-06-10;;Public;PT Dia de Portugal / de Camões e das Comunidades Portuguesas,EN Portugal Day,DE Portugiesischer Nationalfeiertag;
+02c5f3a0-8932-4039-9ecc-ca20513320f6;PT;2029-06-13;;Public;PT Dia de Santo António,EN Feast of St. Anthony,DE Tag des Heiligen Antonius;LI
+68ac4540-811a-4d20-9eea-0040f775a8f8;PT;2029-06-24;;Public;PT Dia de São João Baptista,EN Saint John's Day,DE Johannistag;BRG,ALM,PRT
+af8be653-802a-48e0-82b5-1439dc289028;PT;2029-07-01;;Public;PT Dia da Madeira,EN Madeira Day,DE Madeira-Tag;MA
+261931f3-7962-445b-9800-63152a050a1c;PT;2029-08-15;;Public;PT Assunção de Nossa Senhora,EN Assumption Day,DE Mariä Himmelfahrt;
+052d6345-cff1-488d-8e25-15489d5e3887;PT;2029-10-05;;Public;PT Implantação da República,EN Republic Day,DE Tag der Republik;
+f97d960e-0efa-4a3c-ab9a-324c4f4825ec;PT;2029-11-01;;Public;PT Todos-os-Santos,EN All Saints' Day,DE Allerheiligen;
+7d53e3fe-06d6-4bf2-a75f-a41da5a7eb71;PT;2029-12-01;;Public;PT Restauração da Independência,EN Independence Day,DE Unabhängigkeitstag;
+53cf136f-afbd-4da7-8f7e-db622213bf6e;PT;2029-12-08;;Public;PT Imaculada Conceição,EN Immaculate Conception Day,DE Tag der Unbefleckten Empfängnis;
+e21924bd-355c-4b83-9022-1d81d79e1d2d;PT;2029-12-25;;Public;PT Natal,EN Christmas,DE Weihnachten;
+8dbdd1d4-81e3-4d9c-b868-09137964b4b9;PT;2029-12-26;;Public;PT Primeira Oitava,EN Boxing Day,DE 2. Weihnachtsfeiertag;MA
+bf4a227c-3eef-4de0-aa9f-82526954744e;PT;2030-01-01;;Public;PT Ano Novo,EN New Year's Day,DE Neujahr;
+48c1a1a5-7dc1-4b6f-ba53-74fa0696dca0;PT;2030-04-19;;Public;PT Sexta-feira Santa,EN Good Friday,DE Karfreitag;
+3a48bc16-afd1-474d-a5cd-2ae3da0bd16b;PT;2030-04-21;;Public;PT Domingo de Páscoa,EN Easter Sunday,DE Ostersonntag;
+b68b650b-50a4-4479-90e0-751cf8dbe1da;PT;2030-04-25;;Public;PT Dia da Liberdade,EN Liberty Day,DE Tag der Freiheit;
+2fa31ec1-ddd9-4802-80ce-d64c0eb15504;PT;2030-05-01;;Public;PT Dia do Trabalhador,EN Labor Day,DE Tag der Arbeit;
+57ae8067-ab4a-4e5e-b10c-2c75268dff2c;PT;2030-06-10;;Public;PT Dia de Portugal / de Camões e das Comunidades Portuguesas,EN Portugal Day,DE Portugiesischer Nationalfeiertag;
+25fe2f7e-8b7f-4a22-997d-45d3217c9198;PT;2030-06-20;;Public;PT Corpo de Deus,EN Corpus Christi,DE Fronleichnam;
+0692f101-2e1c-40fd-b6c1-44d7e907f2d0;PT;2030-06-10;;Public;PT Dia dos Açores,EN Azores Day,DE Tag der Azoren;AC
+bd06c21f-3024-499c-b239-d5fca24d6643;PT;2030-06-13;;Public;PT Dia de Santo António,EN Feast of St. Anthony,DE Tag des Heiligen Antonius;LI
+50dada7c-c05e-4096-a7d6-aeccd6256a59;PT;2030-06-24;;Public;PT Dia de São João Baptista,EN Saint John's Day,DE Johannistag;BRG,ALM,PRT
+74a122e2-0d43-4366-8bf5-411e7e295a0e;PT;2030-07-01;;Public;PT Dia da Madeira,EN Madeira Day,DE Madeira-Tag;MA
+bb76bef7-9c2b-45ca-96d5-16032e5a4cb2;PT;2030-08-15;;Public;PT Assunção de Nossa Senhora,EN Assumption Day,DE Mariä Himmelfahrt;
+f953410a-2b67-46fc-a2e9-62e4a02f33de;PT;2030-10-05;;Public;PT Implantação da República,EN Republic Day,DE Tag der Republik;
+264a24bb-75e6-4962-8080-09371c0a0235;PT;2030-11-01;;Public;PT Todos-os-Santos,EN All Saints' Day,DE Allerheiligen;
+58c053b6-32d2-456b-89a3-3d323a2bf841;PT;2030-12-01;;Public;PT Restauração da Independência,EN Independence Day,DE Unabhängigkeitstag;
+8463b389-ccf1-43bc-984a-352e87667d53;PT;2030-12-08;;Public;PT Imaculada Conceição,EN Immaculate Conception Day,DE Tag der Unbefleckten Empfängnis;
+a321f7b4-a646-4c14-8991-14d1f6cbda3e;PT;2030-12-25;;Public;PT Natal,EN Christmas,DE Weihnachten;
+ab137fdc-4334-4494-84bf-13b4b20773b2;PT;2030-12-26;;Public;PT Primeira Oitava,EN Boxing Day,DE 2. Weihnachtsfeiertag;MA

--- a/src/pt/subdivisions.csv
+++ b/src/pt/subdivisions.csv
@@ -1,0 +1,329 @@
+﻿Country;Code;IsoCode;ShortName;Category;Name;OfficialLanguages;Parent
+PT;PT-AV;PT-01;AV;PT distrito,EN district,DE Bezirk;PT Aveiro,EN Aveiro,DE Aveiro;PT;
+PT;PT-BE;PT-02;BE;PT distrito,EN district,DE Bezirk;PT Beja,EN Beja,DE Beja;PT;
+PT;PT-BR;PT-03;BR;PT distrito,EN district,DE Bezirk;PT Braga,EN Braga,DE Braga;PT;
+PT;PT-BA;PT-04;BA;PT distrito,EN district,DE Bezirk;PT Bragança,EN Bragança,DE Bragança;PT;
+PT;PT-CB;PT-05;CB;PT distrito,EN district,DE Bezirk;PT Castelo Branco,EN Castelo Branco,DE Castelo Branco;PT;
+PT;PT-CO;PT-06;CO;PT distrito,EN district,DE Bezirk;PT Coimbra,EN Coimbra,DE Coimbra;PT;
+PT;PT-EV;PT-07;EV;PT distrito,EN district,DE Bezirk;PT Évora,EN Évora,DE Évora;PT;
+PT;PT-FA;PT-08;FA;PT distrito,EN district,DE Bezirk;PT Faro,EN Faro,DE Faro;PT;
+PT;PT-GU;PT-09;GU;PT distrito,EN district,DE Bezirk;PT Guarda,EN Guarda,DE Guarda;PT;
+PT;PT-LE;PT-10;LE;PT distrito,EN district,DE Bezirk;PT Leiria,EN Leiria,DE Leiria;PT;
+PT;PT-LI;PT-11;LI;PT distrito,EN district,DE Bezirk;PT Lisboa,EN Lisbon,DE Lissabon;PT;
+PT;PT-PA;PT-12;PA;PT distrito,EN district,DE Bezirk;PT Portalegre,EN Portalegre,DE Portalegre;PT;
+PT;PT-PO;PT-13;PO;PT distrito,EN district,DE Bezirk;PT Porto,EN Porto,DE Porto;PT;
+PT;PT-SA;PT-14;SA;PT distrito,EN district,DE Bezirk;PT Santarém,EN Santarém,DE Santarém;PT;
+PT;PT-SE;PT-15;SE;PT distrito,EN district,DE Bezirk;PT Setúbal,EN Setúbal,DE Setúbal;PT;
+PT;PT-VC;PT-16;VC;PT distrito,EN district,DE Bezirk;PT Viana do Castelo,EN Viana do Castelo,DE Viana do Castelo;PT;
+PT;PT-VR;PT-17;VR;PT distrito,EN district,DE Bezirk;PT Vila Real,EN Vila Real,DE Vila Real;PT;
+PT;PT-VI;PT-18;VI;PT distrito,EN district,DE Bezirk;PT Viseu,EN Viseu,DE Viseu;PT;
+PT;PT-AC;PT-20;AC;PT região autónoma,EN autonomous region,DE autonome Region;PT Região Autónoma dos Açores,EN Azores,DE Azoren;PT;
+PT;PT-MA;PT-30;MA;PT região autónoma,EN autonomous region,DE autonome Region;PT Região Autónoma da Madeira,EN Madeira,DE Madeira;PT;
+PT;PT-ABT;;ABT;PT municípios,EN municipalities,DE Gemeinden;PT Abrantes,EN Abrantes,DE Abrantes;PT;SA
+PT;PT-AGD;;AGD;PT municípios,EN municipalities,DE Gemeinden;PT Águeda,EN Águeda,DE Águeda;PT;AV
+PT;PT-AGB;;AGB;PT municípios,EN municipalities,DE Gemeinden;PT Aguiar da Beira,EN Aguiar da Beira,DE Aguiar da Beira;PT;GU
+PT;PT-ADL;;ADL;PT municípios,EN municipalities,DE Gemeinden;PT Alandroal,EN Alandroal,DE Alandroal;PT;EV
+PT;PT-ALB;;ALB;PT municípios,EN municipalities,DE Gemeinden;PT Albergaria-a-Velha,EN Albergaria-a-Velha,DE Albergaria-a-Velha;PT;AV
+PT;PT-ABF;;ABF;PT municípios,EN municipalities,DE Gemeinden;PT Albufeira,EN Albufeira,DE Albufeira;PT;FA
+PT;PT-ASL;;ASL;PT municípios,EN municipalities,DE Gemeinden;PT Alcácer do Sal,EN Alcácer do Sal,DE Alcácer do Sal;PT;SE
+PT;PT-ACN;;ACN;PT municípios,EN municipalities,DE Gemeinden;PT Alcanena,EN Alcanena,DE Alcanena;PT;SA
+PT;PT-ACB;;ACB;PT municípios,EN municipalities,DE Gemeinden;PT Alcobaça,EN Alcobaça,DE Alcobaça;PT;LE
+PT;PT-ACH;;ACH;PT municípios,EN municipalities,DE Gemeinden;PT Alcochete,EN Alcochete,DE Alcochete;PT;SE
+PT;PT-ACT;;ACT;PT municípios,EN municipalities,DE Gemeinden;PT Alcoutim,EN Alcoutim,DE Alcoutim;PT;FA
+PT;PT-ALQ;;ALQ;PT municípios,EN municipalities,DE Gemeinden;PT Alenquer,EN Alenquer,DE Alenquer;PT;LI
+PT;PT-AFE;;AFE;PT municípios,EN municipalities,DE Gemeinden;PT Alfândega da Fé,EN Alfândega da Fé,DE Alfândega da Fé;PT;BA
+PT;PT-ALJ;;ALJ;PT municípios,EN municipalities,DE Gemeinden;PT Alijó,EN Alijó,DE Alijó;PT;VR
+PT;PT-AJZ;;AJZ;PT municípios,EN municipalities,DE Gemeinden;PT Aljezur,EN Aljezur,DE Aljezur;PT;FA
+PT;PT-AJT;;AJT;PT municípios,EN municipalities,DE Gemeinden;PT Aljustrel,EN Aljustrel,DE Aljustrel;PT;BE
+PT;PT-ALM;;ALM;PT municípios,EN municipalities,DE Gemeinden;PT Almada,EN Almada,DE Almada;PT;SE
+PT;PT-ALD;;ALD;PT municípios,EN municipalities,DE Gemeinden;PT Almeida,EN Almeida,DE Almeida;PT;GU
+PT;PT-ALR;;ALR;PT municípios,EN municipalities,DE Gemeinden;PT Almeirim,EN Almeirim,DE Almeirim;PT;SA
+PT;PT-ADV;;ADV;PT municípios,EN municipalities,DE Gemeinden;PT Almodôvar,EN Almodôvar,DE Almodôvar;PT;BE
+PT;PT-APC;;APC;PT municípios,EN municipalities,DE Gemeinden;PT Alpiarça,EN Alpiarça,DE Alpiarça;PT;SA
+PT;PT-ALT;;ALT;PT municípios,EN municipalities,DE Gemeinden;PT Alter do Chão,EN Alter do Chão,DE Alter do Chão;PT;PA
+PT;PT-AVZ;;AVZ;PT municípios,EN municipalities,DE Gemeinden;PT Alvaiázere,EN Alvaiázere,DE Alvaiázere;PT;LE
+PT;PT-AVT;;AVT;PT municípios,EN municipalities,DE Gemeinden;PT Alvito,EN Alvito,DE Alvito;PT;BE
+PT;PT-AMD;;AMD;PT municípios,EN municipalities,DE Gemeinden;PT Amadora,EN Amadora,DE Amadora;PT;LI
+PT;PT-AMT;;AMT;PT municípios,EN municipalities,DE Gemeinden;PT Amarante,EN Amarante,DE Amarante;PT;PO
+PT;PT-AMR;;AMR;PT municípios,EN municipalities,DE Gemeinden;PT Amares,EN Amares,DE Amares;PT;BR
+PT;PT-AND;;AND;PT municípios,EN municipalities,DE Gemeinden;PT Anadia,EN Anadia,DE Anadia;PT;AV
+PT;PT-AGH;;AGH;PT municípios,EN municipalities,DE Gemeinden;PT Angra do Heroísmo,EN Angra do Heroísmo,DE Angra do Heroísmo;PT;AC
+PT;PT-ANS;;ANS;PT municípios,EN municipalities,DE Gemeinden;PT Ansião,EN Ansião,DE Ansião;PT;LE
+PT;PT-AVV;;AVV;PT municípios,EN municipalities,DE Gemeinden;PT Arcos de Valdevez,EN Arcos de Valdevez,DE Arcos de Valdevez;PT;VC
+PT;PT-AGN;;AGN;PT municípios,EN municipalities,DE Gemeinden;PT Arganil,EN Arganil,DE Arganil;PT;CO
+PT;PT-AMM;;AMM;PT municípios,EN municipalities,DE Gemeinden;PT Armamar,EN Armamar,DE Armamar;PT;VI
+PT;PT-ARC;;ARC;PT municípios,EN municipalities,DE Gemeinden;PT Arouca,EN Arouca,DE Arouca;PT;AV
+PT;PT-ARL;;ARL;PT municípios,EN municipalities,DE Gemeinden;PT Arraiolos,EN Arraiolos,DE Arraiolos;PT;EV
+PT;PT-ARR;;ARR;PT municípios,EN municipalities,DE Gemeinden;PT Arronches,EN Arronches,DE Arronches;PT;PA
+PT;PT-ARV;;ARV;PT municípios,EN municipalities,DE Gemeinden;PT Arruda dos Vinhos,EN Arruda dos Vinhos,DE Arruda dos Vinhos;PT;LI
+PT;PT-AVR;;AVR;PT municípios,EN municipalities,DE Gemeinden;PT Aveiro,EN Aveiro,DE Aveiro;PT;AV
+PT;PT-AVS;;AVS;PT municípios,EN municipalities,DE Gemeinden;PT Avis,EN Avis,DE Avis;PT;PA
+PT;PT-AZB;;AZB;PT municípios,EN municipalities,DE Gemeinden;PT Azambuja,EN Azambuja,DE Azambuja;PT;LI
+PT;PT-BAO;;BAO;PT municípios,EN municipalities,DE Gemeinden;PT Baião,EN Baião,DE Baião;PT;PO
+PT;PT-BCL;;BCL;PT municípios,EN municipalities,DE Gemeinden;PT Barcelos,EN Barcelos,DE Barcelos;PT;BR
+PT;PT-BRC;;BRC;PT municípios,EN municipalities,DE Gemeinden;PT Barrancos,EN Barrancos,DE Barrancos;PT;BE
+PT;PT-BRR;;BRR;PT municípios,EN municipalities,DE Gemeinden;PT Barreiro,EN Barreiro,DE Barreiro;PT;SE
+PT;PT-BTL;;BTL;PT municípios,EN municipalities,DE Gemeinden;PT Batalha,EN Batalha,DE Batalha;PT;LE
+PT;PT-BJA;;BJA;PT municípios,EN municipalities,DE Gemeinden;PT Beja,EN Beja,DE Beja;PT;BE
+PT;PT-BMT;;BMT;PT municípios,EN municipalities,DE Gemeinden;PT Belmonte,EN Belmonte,DE Belmonte;PT;CB
+PT;PT-BNV;;BNV;PT municípios,EN municipalities,DE Gemeinden;PT Benavente,EN Benavente,DE Benavente;PT;SA
+PT;PT-BBR;;BBR;PT municípios,EN municipalities,DE Gemeinden;PT Bombarral,EN Bombarral,DE Bombarral;PT;LE
+PT;PT-BRB;;BRB;PT municípios,EN municipalities,DE Gemeinden;PT Borba,EN Borba,DE Borba;PT;EV
+PT;PT-BTC;;BTC;PT municípios,EN municipalities,DE Gemeinden;PT Boticas,EN Boticas,DE Boticas;PT;VR
+PT;PT-BRG;;BRG;PT municípios,EN municipalities,DE Gemeinden;PT Braga,EN Braga,DE Braga;PT;BR
+PT;PT-BGC;;BGC;PT municípios,EN municipalities,DE Gemeinden;PT Bragança,EN Bragança,DE Bragança;PT;BA
+PT;PT-CBC;;CBC;PT municípios,EN municipalities,DE Gemeinden;PT Cabeceiras de Basto,EN Cabeceiras de Basto,DE Cabeceiras de Basto;PT;BR
+PT;PT-CDV;;CDV;PT municípios,EN municipalities,DE Gemeinden;PT Cadaval,EN Cadaval,DE Cadaval;PT;LI
+PT;PT-CLD;;CLD;PT municípios,EN municipalities,DE Gemeinden;PT Caldas da Rainha,EN Caldas da Rainha,DE Caldas da Rainha;PT;LE
+PT;PT-CHT;;CHT;PT municípios,EN municipalities,DE Gemeinden;PT Calheta (Açores),EN Calheta (Azores),DE Calheta (Azoren);PT;AC
+PT;PT-CLT;;CLT;PT municípios,EN municipalities,DE Gemeinden;PT Calheta (Madeira),EN Calheta (Madeira),DE Calheta (Madeira);PT;MA
+PT;PT-CML;;CML;PT municípios,EN municipalities,DE Gemeinden;PT Câmara de Lobos,EN Câmara de Lobos,DE Câmara de Lobos;PT;MA
+PT;PT-CMN;;CMN;PT municípios,EN municipalities,DE Gemeinden;PT Caminha,EN Caminha,DE Caminha;PT;VC
+PT;PT-CMR;;CMR;PT municípios,EN municipalities,DE Gemeinden;PT Campo Maior,EN Campo Maior,DE Campo Maior;PT;PA
+PT;PT-CNT;;CNT;PT municípios,EN municipalities,DE Gemeinden;PT Cantanhede,EN Cantanhede,DE Cantanhede;PT;CO
+PT;PT-CRZ;;CRZ;PT municípios,EN municipalities,DE Gemeinden;PT Carrazeda de Ansiães,EN Carrazeda de Ansiães,DE Carrazeda de Ansiães;PT;BA
+PT;PT-CRS;;CRS;PT municípios,EN municipalities,DE Gemeinden;PT Carregal do Sal,EN Carregal do Sal,DE Carregal do Sal;PT;VI
+PT;PT-CTX;;CTX;PT municípios,EN municipalities,DE Gemeinden;PT Cartaxo,EN Cartaxo,DE Cartaxo;PT;SA
+PT;PT-CSC;;CSC;PT municípios,EN municipalities,DE Gemeinden;PT Cascais,EN Cascais,DE Cascais;PT;LI
+PT;PT-CPR;;CPR;PT municípios,EN municipalities,DE Gemeinden;PT Castanheira de Pera,EN Castanheira de Pera,DE Castanheira de Pera;PT;LE
+PT;PT-CTB;;CTB;PT municípios,EN municipalities,DE Gemeinden;PT Castelo Branco,EN Castelo Branco,DE Castelo Branco;PT;CB
+PT;PT-CPV;;CPV;PT municípios,EN municipalities,DE Gemeinden;PT Castelo de Paiva,EN Castelo de Paiva,DE Castelo de Paiva;PT;AV
+PT;PT-CVD;;CVD;PT municípios,EN municipalities,DE Gemeinden;PT Castelo de Vide,EN Castelo de Vide,DE Castelo de Vide;PT;PA
+PT;PT-CDR;;CDR;PT municípios,EN municipalities,DE Gemeinden;PT Castro Daire,EN Castro Daire,DE Castro Daire;PT;VI
+PT;PT-CTM;;CTM;PT municípios,EN municipalities,DE Gemeinden;PT Castro Marim,EN Castro Marim,DE Castro Marim;PT;FA
+PT;PT-CVR;;CVR;PT municípios,EN municipalities,DE Gemeinden;PT Castro Verde,EN Castro Verde,DE Castro Verde;PT;BE
+PT;PT-CLB;;CLB;PT municípios,EN municipalities,DE Gemeinden;PT Celorico da Beira,EN Celorico da Beira,DE Celorico da Beira;PT;GU
+PT;PT-CBT;;CBT;PT municípios,EN municipalities,DE Gemeinden;PT Celorico de Basto,EN Celorico de Basto,DE Celorico de Basto;PT;BR
+PT;PT-CHM;;CHM;PT municípios,EN municipalities,DE Gemeinden;PT Chamusca,EN Chamusca,DE Chamusca;PT;SA
+PT;PT-CHV;;CHV;PT municípios,EN municipalities,DE Gemeinden;PT Chaves,EN Chaves,DE Chaves;PT;VR
+PT;PT-CNF;;CNF;PT municípios,EN municipalities,DE Gemeinden;PT Cinfães,EN Cinfães,DE Cinfães;PT;VI
+PT;PT-CBR;;CBR;PT municípios,EN municipalities,DE Gemeinden;PT Coimbra,EN Coimbra,DE Coimbra;PT;CO
+PT;PT-CDN;;CDN;PT municípios,EN municipalities,DE Gemeinden;PT Condeixa-a-Nova,EN Condeixa-a-Nova,DE Condeixa-a-Nova;PT;CO
+PT;PT-CNS;;CNS;PT municípios,EN municipalities,DE Gemeinden;PT Constância,EN Constância,DE Constância;PT;SA
+PT;PT-CCH;;CCH;PT municípios,EN municipalities,DE Gemeinden;PT Coruche,EN Coruche,DE Coruche;PT;SA
+PT;PT-CRV;;CRV;PT municípios,EN municipalities,DE Gemeinden;PT Corvo,EN Corvo,DE Corvo;PT;AC
+PT;PT-CVL;;CVL;PT municípios,EN municipalities,DE Gemeinden;PT Covilhã,EN Covilhã,DE Covilhã;PT;CB
+PT;PT-CRT;;CRT;PT municípios,EN municipalities,DE Gemeinden;PT Crato,EN Crato,DE Crato;PT;PA
+PT;PT-CBA;;CBA;PT municípios,EN municipalities,DE Gemeinden;PT Cuba,EN Cuba,DE Cuba;PT;BE
+PT;PT-ELV;;ELV;PT municípios,EN municipalities,DE Gemeinden;PT Elvas,EN Elvas,DE Elvas;PT;PA
+PT;PT-ENT;;ENT;PT municípios,EN municipalities,DE Gemeinden;PT Entroncamento,EN Entroncamento,DE Entroncamento;PT;SA
+PT;PT-ESP;;ESP;PT municípios,EN municipalities,DE Gemeinden;PT Espinho,EN Espinho,DE Espinho;PT;AV
+PT;PT-EPS;;EPS;PT municípios,EN municipalities,DE Gemeinden;PT Esposende,EN Esposende,DE Esposende;PT;BR
+PT;PT-ETR;;ETR;PT municípios,EN municipalities,DE Gemeinden;PT Estarreja,EN Estarreja,DE Estarreja;PT;AV
+PT;PT-ETZ;;ETZ;PT municípios,EN municipalities,DE Gemeinden;PT Estremoz,EN Estremoz,DE Estremoz;PT;EV
+PT;PT-EVR;;EVR;PT municípios,EN municipalities,DE Gemeinden;PT Évora,EN Évora,DE Évora;PT;EV
+PT;PT-FAF;;FAF;PT municípios,EN municipalities,DE Gemeinden;PT Fafe,EN Fafe,DE Fafe;PT;BR
+PT;PT-FAR;;FAR;PT municípios,EN municipalities,DE Gemeinden;PT Faro,EN Faro,DE Faro;PT;FA
+PT;PT-FLG;;FLG;PT municípios,EN municipalities,DE Gemeinden;PT Felgueiras,EN Felgueiras,DE Felgueiras;PT;PO
+PT;PT-FAL;;FAL;PT municípios,EN municipalities,DE Gemeinden;PT Ferreira do Alentejo,EN Ferreira do Alentejo,DE Ferreira do Alentejo;PT;BE
+PT;PT-FZZ;;FZZ;PT municípios,EN municipalities,DE Gemeinden;PT Ferreira do Zêzere,EN Ferreira do Zêzere,DE Ferreira do Zêzere;PT;SA
+PT;PT-FIG;;FIG;PT municípios,EN municipalities,DE Gemeinden;PT Figueira da Foz,EN Figueira da Foz,DE Figueira da Foz;PT;CO
+PT;PT-FCR;;FCR;PT municípios,EN municipalities,DE Gemeinden;PT Figueira de Castelo Rodrigo,EN Figueira de Castelo Rodrigo,DE Figueira de Castelo Rodrigo;PT;GU
+PT;PT-FVN;;FVN;PT municípios,EN municipalities,DE Gemeinden;PT Figueiró dos Vinhos,EN Figueiró dos Vinhos,DE Figueiró dos Vinhos;PT;LE
+PT;PT-FAG;;FAG;PT municípios,EN municipalities,DE Gemeinden;PT Fornos de Algodres,EN Fornos de Algodres,DE Fornos de Algodres;PT;GU
+PT;PT-FEC;;FEC;PT municípios,EN municipalities,DE Gemeinden;PT Freixo de Espada à Cinta,EN Freixo de Espada à Cinta,DE Freixo de Espada à Cinta;PT;BA
+PT;PT-FTR;;FTR;PT municípios,EN municipalities,DE Gemeinden;PT Fronteira,EN Fronteira,DE Fronteira;PT;PA
+PT;PT-FNC;;FNC;PT municípios,EN municipalities,DE Gemeinden;PT Funchal,EN Funchal,DE Funchal;PT;MA
+PT;PT-FND;;FND;PT municípios,EN municipalities,DE Gemeinden;PT Fundão,EN Fundão,DE Fundão;PT;CB
+PT;PT-GAV;;GAV;PT municípios,EN municipalities,DE Gemeinden;PT Gavião,EN Gavião,DE Gavião;PT;PA
+PT;PT-GOI;;GOI;PT municípios,EN municipalities,DE Gemeinden;PT Góis,EN Góis,DE Góis;PT;CO
+PT;PT-GLG;;GLG;PT municípios,EN municipalities,DE Gemeinden;PT Golegã,EN Golegã,DE Golegã;PT;SA
+PT;PT-GDM;;GDM;PT municípios,EN municipalities,DE Gemeinden;PT Gondomar,EN Gondomar,DE Gondomar;PT;PO
+PT;PT-GVA;;GVA;PT municípios,EN municipalities,DE Gemeinden;PT Gouveia,EN Gouveia,DE Gouveia;PT;GU
+PT;PT-GDL;;GDL;PT municípios,EN municipalities,DE Gemeinden;PT Grândola,EN Grândola,DE Grândola;PT;SE
+PT;PT-GRD;;GRD;PT municípios,EN municipalities,DE Gemeinden;PT Guarda,EN Guarda,DE Guarda;PT;GU
+PT;PT-GMR;;GMR;PT municípios,EN municipalities,DE Gemeinden;PT Guimarães,EN Guimarães,DE Guimarães;PT;BR
+PT;PT-HRT;;HRT;PT municípios,EN municipalities,DE Gemeinden;PT Horta,EN Horta,DE Horta;PT;AC
+PT;PT-IDN;;IDN;PT municípios,EN municipalities,DE Gemeinden;PT Idanha-a-Nova,EN Idanha-a-Nova,DE Idanha-a-Nova;PT;CB
+PT;PT-ILH;;ILH;PT municípios,EN municipalities,DE Gemeinden;PT Ílhavo,EN Ílhavo,DE Ílhavo;PT;AV
+PT;PT-LGA;;LGA;PT municípios,EN municipalities,DE Gemeinden;PT Lagoa (Algarve),EN Lagoa (Algarve),DE Lagoa (Algarve);PT;FA
+PT;PT-LAG;;LAG;PT municípios,EN municipalities,DE Gemeinden;PT Lagoa (Açores),EN Lagoa (Azores),DE Lagoa (Azoren);PT;AC
+PT;PT-LGS;;LGS;PT municípios,EN municipalities,DE Gemeinden;PT Lagos,EN Lagos,DE Lagos;PT;FA
+PT;PT-LGF;;LGF;PT municípios,EN municipalities,DE Gemeinden;PT Lajes das Flores,EN Lajes das Flores,DE Lajes das Flores;PT;AC
+PT;PT-LGP;;LGP;PT municípios,EN municipalities,DE Gemeinden;PT Lajes do Pico,EN Lajes do Pico,DE Lajes do Pico;PT;AC
+PT;PT-LMG;;LMG;PT municípios,EN municipalities,DE Gemeinden;PT Lamego,EN Lamego,DE Lamego;PT;VI
+PT;PT-LRA;;LRA;PT municípios,EN municipalities,DE Gemeinden;PT Leiria,EN Leiria,DE Leiria;PT;LE
+PT;PT-LSB;;LSB;PT municípios,EN municipalities,DE Gemeinden;PT Lisboa,EN Lisbon,DE Lissabon;PT;LI
+PT;PT-LLE;;LLE;PT municípios,EN municipalities,DE Gemeinden;PT Loulé,EN Loulé,DE Loulé;PT;FA
+PT;PT-LRS;;LRS;PT municípios,EN municipalities,DE Gemeinden;PT Loures,EN Loures,DE Loures;PT;LI
+PT;PT-LNH;;LNH;PT municípios,EN municipalities,DE Gemeinden;PT Lourinhã,EN Lourinhã,DE Lourinhã;PT;LI
+PT;PT-LSA;;LSA;PT municípios,EN municipalities,DE Gemeinden;PT Lousã,EN Lousã,DE Lousã;PT;CO
+PT;PT-LOU;;LOU;PT municípios,EN municipalities,DE Gemeinden;PT Lousada,EN Lousada,DE Lousada;PT;PO
+PT;PT-MAC;;MAC;PT municípios,EN municipalities,DE Gemeinden;PT Mação,EN Mação,DE Mação;PT;SA
+PT;PT-MCD;;MCD;PT municípios,EN municipalities,DE Gemeinden;PT Macedo de Cavaleiros,EN Macedo de Cavaleiros,DE Macedo de Cavaleiros;PT;BA
+PT;PT-MCH;;MCH;PT municípios,EN municipalities,DE Gemeinden;PT Machico,EN Machico,DE Machico;PT;MA
+PT;PT-MAD;;MAD;PT municípios,EN municipalities,DE Gemeinden;PT Madalena,EN Madalena,DE Madalena;PT;AC
+PT;PT-MFR;;MFR;PT municípios,EN municipalities,DE Gemeinden;PT Mafra,EN Mafra,DE Mafra;PT;LI
+PT;PT-MAI;;MAI;PT municípios,EN municipalities,DE Gemeinden;PT Maia,EN Maia,DE Maia;PT;PO
+PT;PT-MGL;;MGL;PT municípios,EN municipalities,DE Gemeinden;PT Mangualde,EN Mangualde,DE Mangualde;PT;VI
+PT;PT-MTG;;MTG;PT municípios,EN municipalities,DE Gemeinden;PT Manteigas,EN Manteigas,DE Manteigas;PT;GU
+PT;PT-MCN;;MCN;PT municípios,EN municipalities,DE Gemeinden;PT Marco de Canaveses,EN Marco de Canaveses,DE Marco de Canaveses;PT;PO
+PT;PT-MGR;;MGR;PT municípios,EN municipalities,DE Gemeinden;PT Marinha Grande,EN Marinha Grande,DE Marinha Grande;PT;LE
+PT;PT-MRV;;MRV;PT municípios,EN municipalities,DE Gemeinden;PT Marvão,EN Marvão,DE Marvão;PT;PA
+PT;PT-MTS;;MTS;PT municípios,EN municipalities,DE Gemeinden;PT Matosinhos,EN Matosinhos,DE Matosinhos;PT;PO
+PT;PT-MLD;;MLD;PT municípios,EN municipalities,DE Gemeinden;PT Mealhada,EN Mealhada,DE Mealhada;PT;AV
+PT;PT-MED;;MED;PT municípios,EN municipalities,DE Gemeinden;PT Mêda,EN Mêda,DE Mêda;PT;GU
+PT;PT-MLG;;MLG;PT municípios,EN municipalities,DE Gemeinden;PT Melgaço,EN Melgaço,DE Melgaço;PT;VC
+PT;PT-MTL;;MTL;PT municípios,EN municipalities,DE Gemeinden;PT Mértola,EN Mértola,DE Mértola;PT;BE
+PT;PT-MSF;;MSF;PT municípios,EN municipalities,DE Gemeinden;PT Mesão Frio,EN Mesão Frio,DE Mesão Frio;PT;VR
+PT;PT-MIR;;MIR;PT municípios,EN municipalities,DE Gemeinden;PT Mira,EN Mira,DE Mira;PT;CO
+PT;PT-MCV;;MCV;PT municípios,EN municipalities,DE Gemeinden;PT Miranda do Corvo,EN Miranda do Corvo,DE Miranda do Corvo;PT;CO
+PT;PT-MDR;;MDR;PT municípios,EN municipalities,DE Gemeinden;PT Miranda do Douro (Miranda de l Douro),EN Miranda do Douro (Miranda de l Douro),DE Miranda do Douro (Miranda de l Douro);PT;BA
+PT;PT-MDL;;MDL;PT municípios,EN municipalities,DE Gemeinden;PT Mirandela,EN Mirandela,DE Mirandela;PT;BA
+PT;PT-MGD;;MGD;PT municípios,EN municipalities,DE Gemeinden;PT Mogadouro,EN Mogadouro,DE Mogadouro;PT;BA
+PT;PT-MBR;;MBR;PT municípios,EN municipalities,DE Gemeinden;PT Moimenta da Beira,EN Moimenta da Beira,DE Moimenta da Beira;PT;VI
+PT;PT-MTA;;MTA;PT municípios,EN municipalities,DE Gemeinden;PT Moita,EN Moita,DE Moita;PT;SE
+PT;PT-MNC;;MNC;PT municípios,EN municipalities,DE Gemeinden;PT Monção,EN Monção,DE Monção;PT;VC
+PT;PT-MCQ;;MCQ;PT municípios,EN municipalities,DE Gemeinden;PT Monchique,EN Monchique,DE Monchique;PT;FA
+PT;PT-MDB;;MDB;PT municípios,EN municipalities,DE Gemeinden;PT Mondim de Basto,EN Mondim de Basto,DE Mondim de Basto;PT;VR
+PT;PT-MFT;;MFT;PT municípios,EN municipalities,DE Gemeinden;PT Monforte,EN Monforte,DE Monforte;PT;PA
+PT;PT-MTR;;MTR;PT municípios,EN municipalities,DE Gemeinden;PT Montalegre,EN Montalegre,DE Montalegre;PT;VR
+PT;PT-MMN;;MMN;PT municípios,EN municipalities,DE Gemeinden;PT Montemor-o-Novo,EN Montemor-o-Novo,DE Montemor-o-Novo;PT;EV
+PT;PT-MMV;;MMV;PT municípios,EN municipalities,DE Gemeinden;PT Montemor-o-Velho,EN Montemor-o-Velho,DE Montemor-o-Velho;PT;CO
+PT;PT-MTJ;;MTJ;PT municípios,EN municipalities,DE Gemeinden;PT Montijo,EN Montijo,DE Montijo;PT;SE
+PT;PT-MOR;;MOR;PT municípios,EN municipalities,DE Gemeinden;PT Mora,EN Mora,DE Mora;PT;EV
+PT;PT-MRT;;MRT;PT municípios,EN municipalities,DE Gemeinden;PT Mortágua,EN Mortágua,DE Mortágua;PT;VI
+PT;PT-MRA;;MRA;PT municípios,EN municipalities,DE Gemeinden;PT Moura,EN Moura,DE Moura;PT;BE
+PT;PT-MOU;;MOU;PT municípios,EN municipalities,DE Gemeinden;PT Mourão,EN Mourão,DE Mourão;PT;EV
+PT;PT-MUR;;MUR;PT municípios,EN municipalities,DE Gemeinden;PT Murça,EN Murça,DE Murça;PT;VR
+PT;PT-MRS;;MRS;PT municípios,EN municipalities,DE Gemeinden;PT Murtosa,EN Murtosa,DE Murtosa;PT;AV
+PT;PT-NZR;;NZR;PT municípios,EN municipalities,DE Gemeinden;PT Nazaré,EN Nazaré,DE Nazaré;PT;LE
+PT;PT-NLS;;NLS;PT municípios,EN municipalities,DE Gemeinden;PT Nelas,EN Nelas,DE Nelas;PT;VI
+PT;PT-NIS;;NIS;PT municípios,EN municipalities,DE Gemeinden;PT Nisa,EN Nisa,DE Nisa;PT;PA
+PT;PT-NRD;;NRD;PT municípios,EN municipalities,DE Gemeinden;PT Nordeste,EN Nordeste,DE Nordeste;PT;AC
+PT;PT-OBD;;OBD;PT municípios,EN municipalities,DE Gemeinden;PT Óbidos,EN Óbidos,DE Óbidos;PT;LE
+PT;PT-ODM;;ODM;PT municípios,EN municipalities,DE Gemeinden;PT Odemira,EN Odemira,DE Odemira;PT;BE
+PT;PT-ODV;;ODV;PT municípios,EN municipalities,DE Gemeinden;PT Odivelas,EN Odivelas,DE Odivelas;PT;LI
+PT;PT-OER;;OER;PT municípios,EN municipalities,DE Gemeinden;PT Oeiras,EN Oeiras,DE Oeiras;PT;LI
+PT;PT-OLR;;OLR;PT municípios,EN municipalities,DE Gemeinden;PT Oleiros,EN Oleiros,DE Oleiros;PT;CB
+PT;PT-OLH;;OLH;PT municípios,EN municipalities,DE Gemeinden;PT Olhão,EN Olhão,DE Olhão;PT;FA
+PT;PT-OAZ;;OAZ;PT municípios,EN municipalities,DE Gemeinden;PT Oliveira de Azeméis,EN Oliveira de Azeméis,DE Oliveira de Azeméis;PT;AV
+PT;PT-OFR;;OFR;PT municípios,EN municipalities,DE Gemeinden;PT Oliveira de Frades,EN Oliveira de Frades,DE Oliveira de Frades;PT;VI
+PT;PT-OBR;;OBR;PT municípios,EN municipalities,DE Gemeinden;PT Oliveira do Bairro,EN Oliveira do Bairro,DE Oliveira do Bairro;PT;AV
+PT;PT-OHP;;OHP;PT municípios,EN municipalities,DE Gemeinden;PT Oliveira do Hospital,EN Oliveira do Hospital,DE Oliveira do Hospital;PT;CO
+PT;PT-ORM;;ORM;PT municípios,EN municipalities,DE Gemeinden;PT Ourém,EN Ourém,DE Ourém;PT;SA
+PT;PT-ORQ;;ORQ;PT municípios,EN municipalities,DE Gemeinden;PT Ourique,EN Ourique,DE Ourique;PT;BE
+PT;PT-OVR;;OVR;PT municípios,EN municipalities,DE Gemeinden;PT Ovar,EN Ovar,DE Ovar;PT;AV
+PT;PT-PFR;;PFR;PT municípios,EN municipalities,DE Gemeinden;PT Paços de Ferreira,EN Paços de Ferreira,DE Paços de Ferreira;PT;PO
+PT;PT-PLM;;PLM;PT municípios,EN municipalities,DE Gemeinden;PT Palmela,EN Palmela,DE Palmela;PT;SE
+PT;PT-PPS;;PPS;PT municípios,EN municipalities,DE Gemeinden;PT Pampilhosa da Serra,EN Pampilhosa da Serra,DE Pampilhosa da Serra;PT;CO
+PT;PT-PRD;;PRD;PT municípios,EN municipalities,DE Gemeinden;PT Paredes,EN Paredes,DE Paredes;PT;PO
+PT;PT-PCR;;PCR;PT municípios,EN municipalities,DE Gemeinden;PT Paredes de Coura,EN Paredes de Coura,DE Paredes de Coura;PT;VC
+PT;PT-PGR;;PGR;PT municípios,EN municipalities,DE Gemeinden;PT Pedrógão Grande,EN Pedrógão Grande,DE Pedrógão Grande;PT;LE
+PT;PT-PCV;;PCV;PT municípios,EN municipalities,DE Gemeinden;PT Penacova,EN Penacova,DE Penacova;PT;CO
+PT;PT-PNF;;PNF;PT municípios,EN municipalities,DE Gemeinden;PT Penafiel,EN Penafiel,DE Penafiel;PT;PO
+PT;PT-PCT;;PCT;PT municípios,EN municipalities,DE Gemeinden;PT Penalva do Castelo,EN Penalva do Castelo,DE Penalva do Castelo;PT;VI
+PT;PT-PNC;;PNC;PT municípios,EN municipalities,DE Gemeinden;PT Penamacor,EN Penamacor,DE Penamacor;PT;CB
+PT;PT-PND;;PND;PT municípios,EN municipalities,DE Gemeinden;PT Penedono,EN Penedono,DE Penedono;PT;VI
+PT;PT-PNL;;PNL;PT municípios,EN municipalities,DE Gemeinden;PT Penela,EN Penela,DE Penela;PT;CO
+PT;PT-PNI;;PNI;PT municípios,EN municipalities,DE Gemeinden;PT Peniche,EN Peniche,DE Peniche;PT;LE
+PT;PT-PRG;;PRG;PT municípios,EN municipalities,DE Gemeinden;PT Peso da Régua,EN Peso da Régua,DE Peso da Régua;PT;VR
+PT;PT-PNH;;PNH;PT municípios,EN municipalities,DE Gemeinden;PT Pinhel,EN Pinhel,DE Pinhel;PT;GU
+PT;PT-PBL;;PBL;PT municípios,EN municipalities,DE Gemeinden;PT Pombal,EN Pombal,DE Pombal;PT;LE
+PT;PT-PDL;;PDL;PT municípios,EN municipalities,DE Gemeinden;PT Ponta Delgada,EN Ponta Delgada,DE Ponta Delgada;PT;AC
+PT;PT-PTS;;PTS;PT municípios,EN municipalities,DE Gemeinden;PT Ponta do Sol,EN Ponta do Sol,DE Ponta do Sol;PT;MA
+PT;PT-PTB;;PTB;PT municípios,EN municipalities,DE Gemeinden;PT Ponte da Barca,EN Ponte da Barca,DE Ponte da Barca;PT;VC
+PT;PT-PTL;;PTL;PT municípios,EN municipalities,DE Gemeinden;PT Ponte de Lima,EN Ponte de Lima,DE Ponte de Lima;PT;VC
+PT;PT-PSR;;PSR;PT municípios,EN municipalities,DE Gemeinden;PT Ponte de Sor,EN Ponte de Sor,DE Ponte de Sor;PT;PA
+PT;PT-PTG;;PTG;PT municípios,EN municipalities,DE Gemeinden;PT Portalegre,EN Portalegre,DE Portalegre;PT;PA
+PT;PT-PRL;;PRL;PT municípios,EN municipalities,DE Gemeinden;PT Portel,EN Portel,DE Portel;PT;EV
+PT;PT-PTM;;PTM;PT municípios,EN municipalities,DE Gemeinden;PT Portimão,EN Portimão,DE Portimão;PT;FA
+PT;PT-PRT;;PRT;PT municípios,EN municipalities,DE Gemeinden;PT Porto,EN Porto,DE Porto;PT;PO
+PT;PT-PMS;;PMS;PT municípios,EN municipalities,DE Gemeinden;PT Porto de Mós,EN Porto de Mós,DE Porto de Mós;PT;LE
+PT;PT-PMZ;;PMZ;PT municípios,EN municipalities,DE Gemeinden;PT Porto Moniz,EN Porto Moniz,DE Porto Moniz;PT;MA
+PT;PT-PST;;PST;PT municípios,EN municipalities,DE Gemeinden;PT Porto Santo,EN Porto Santo,DE Porto Santo;PT;MA
+PT;PT-PVL;;PVL;PT municípios,EN municipalities,DE Gemeinden;PT Póvoa de Lanhoso,EN Póvoa de Lanhoso,DE Póvoa de Lanhoso;PT;BR
+PT;PT-PVZ;;PVZ;PT municípios,EN municipalities,DE Gemeinden;PT Póvoa de Varzim,EN Póvoa de Varzim,DE Póvoa de Varzim;PT;PO
+PT;PT-PVC;;PVC;PT municípios,EN municipalities,DE Gemeinden;PT Povoação,EN Povoação,DE Povoação;PT;AC
+PT;PT-VPV;;VPV;PT municípios,EN municipalities,DE Gemeinden;PT Praia da Vitória,EN Praia da Vitória,DE Praia da Vitória;PT;AC
+PT;PT-PNV;;PNV;PT municípios,EN municipalities,DE Gemeinden;PT Proença-a-Nova,EN Proença-a-Nova,DE Proença-a-Nova;PT;CB
+PT;PT-RDD;;RDD;PT municípios,EN municipalities,DE Gemeinden;PT Redondo,EN Redondo,DE Redondo;PT;EV
+PT;PT-RMZ;;RMZ;PT municípios,EN municipalities,DE Gemeinden;PT Reguengos de Monsaraz,EN Reguengos de Monsaraz,DE Reguengos de Monsaraz;PT;EV
+PT;PT-RSD;;RSD;PT municípios,EN municipalities,DE Gemeinden;PT Resende,EN Resende,DE Resende;PT;VI
+PT;PT-RBR;;RBR;PT municípios,EN municipalities,DE Gemeinden;PT Ribeira Brava,EN Ribeira Brava,DE Ribeira Brava;PT;MA
+PT;PT-RPN;;RPN;PT municípios,EN municipalities,DE Gemeinden;PT Ribeira de Pena,EN Ribeira de Pena,DE Ribeira de Pena;PT;VR
+PT;PT-RGR;;RGR;PT municípios,EN municipalities,DE Gemeinden;PT Ribeira Grande,EN Ribeira Grande,DE Ribeira Grande;PT;AC
+PT;PT-RMR;;RMR;PT municípios,EN municipalities,DE Gemeinden;PT Rio Maior,EN Rio Maior,DE Rio Maior;PT;SA
+PT;PT-SBR;;SBR;PT municípios,EN municipalities,DE Gemeinden;PT Sabrosa,EN Sabrosa,DE Sabrosa;PT;VR
+PT;PT-SBG;;SBG;PT municípios,EN municipalities,DE Gemeinden;PT Sabugal,EN Sabugal,DE Sabugal;PT;GU
+PT;PT-SMG;;SMG;PT municípios,EN municipalities,DE Gemeinden;PT Salvaterra de Magos,EN Salvaterra de Magos,DE Salvaterra de Magos;PT;SA
+PT;PT-SCD;;SCD;PT municípios,EN municipalities,DE Gemeinden;PT Santa Comba Dão,EN Santa Comba Dão,DE Santa Comba Dão;PT;VI
+PT;PT-SCR;;SCR;PT municípios,EN municipalities,DE Gemeinden;PT Santa Cruz,EN Santa Cruz,DE Santa Cruz;PT;MA
+PT;PT-SCG;;SCG;PT municípios,EN municipalities,DE Gemeinden;PT Santa Cruz da Graciosa,EN Santa Cruz da Graciosa,DE Santa Cruz da Graciosa;PT;AC
+PT;PT-SCF;;SCF;PT municípios,EN municipalities,DE Gemeinden;PT Santa Cruz das Flores,EN Santa Cruz das Flores,DE Santa Cruz das Flores;PT;AC
+PT;PT-VFR;;VFR;PT municípios,EN municipalities,DE Gemeinden;PT Santa Maria da Feira,EN Santa Maria da Feira,DE Santa Maria da Feira;PT;AV
+PT;PT-SMP;;SMP;PT municípios,EN municipalities,DE Gemeinden;PT Santa Marta de Penaguião,EN Santa Marta de Penaguião,DE Santa Marta de Penaguião;PT;VR
+PT;PT-STN;;STN;PT municípios,EN municipalities,DE Gemeinden;PT Santana,EN Santana,DE Santana;PT;MA
+PT;PT-STR;;STR;PT municípios,EN municipalities,DE Gemeinden;PT Santarém,EN Santarém,DE Santarém;PT;SA
+PT;PT-STC;;STC;PT municípios,EN municipalities,DE Gemeinden;PT Santiago do Cacém,EN Santiago do Cacém,DE Santiago do Cacém;PT;SE
+PT;PT-STS;;STS;PT municípios,EN municipalities,DE Gemeinden;PT Santo Tirso,EN Santo Tirso,DE Santo Tirso;PT;PO
+PT;PT-SBA;;SBA;PT municípios,EN municipalities,DE Gemeinden;PT São Brás de Alportel,EN São Brás de Alportel,DE São Brás de Alportel;PT;FA
+PT;PT-SJM;;SJM;PT municípios,EN municipalities,DE Gemeinden;PT São João da Madeira,EN São João da Madeira,DE São João da Madeira;PT;AV
+PT;PT-SJP;;SJP;PT municípios,EN municipalities,DE Gemeinden;PT São João da Pesqueira,EN São João da Pesqueira,DE São João da Pesqueira;PT;VI
+PT;PT-SPS;;SPS;PT municípios,EN municipalities,DE Gemeinden;PT São Pedro do Sul,EN São Pedro do Sul,DE São Pedro do Sul;PT;VI
+PT;PT-SRQ;;SRQ;PT municípios,EN municipalities,DE Gemeinden;PT São Roque do Pico,EN São Roque do Pico,DE São Roque do Pico;PT;AC
+PT;PT-SVC;;SVC;PT municípios,EN municipalities,DE Gemeinden;PT São Vicente,EN São Vicente,DE São Vicente;PT;MA
+PT;PT-SRD;;SRD;PT municípios,EN municipalities,DE Gemeinden;PT Sardoal,EN Sardoal,DE Sardoal;PT;SA
+PT;PT-SAT;;SAT;PT municípios,EN municipalities,DE Gemeinden;PT Sátão,EN Sátão,DE Sátão;PT;VI
+PT;PT-SEI;;SEI;PT municípios,EN municipalities,DE Gemeinden;PT Seia,EN Seia,DE Seia;PT;GU
+PT;PT-SXL;;SXL;PT municípios,EN municipalities,DE Gemeinden;PT Seixal,EN Seixal,DE Seixal;PT;SE
+PT;PT-SRN;;SRN;PT municípios,EN municipalities,DE Gemeinden;PT Sernancelhe,EN Sernancelhe,DE Sernancelhe;PT;VI
+PT;PT-SRP;;SRP;PT municípios,EN municipalities,DE Gemeinden;PT Serpa,EN Serpa,DE Serpa;PT;BE
+PT;PT-SRT;;SRT;PT municípios,EN municipalities,DE Gemeinden;PT Sertã,EN Sertã,DE Sertã;PT;CB
+PT;PT-SSB;;SSB;PT municípios,EN municipalities,DE Gemeinden;PT Sesimbra,EN Sesimbra,DE Sesimbra;PT;SE
+PT;PT-STB;;STB;PT municípios,EN municipalities,DE Gemeinden;PT Setúbal,EN Setúbal,DE Setúbal;PT;SE
+PT;PT-SVV;;SVV;PT municípios,EN municipalities,DE Gemeinden;PT Sever do Vouga,EN Sever do Vouga,DE Sever do Vouga;PT;AV
+PT;PT-SLV;;SLV;PT municípios,EN municipalities,DE Gemeinden;PT Silves,EN Silves,DE Silves;PT;FA
+PT;PT-SNS;;SNS;PT municípios,EN municipalities,DE Gemeinden;PT Sines,EN Sines,DE Sines;PT;SE
+PT;PT-SNT;;SNT;PT municípios,EN municipalities,DE Gemeinden;PT Sintra,EN Sintra,DE Sintra;PT;LI
+PT;PT-SMA;;SMA;PT municípios,EN municipalities,DE Gemeinden;PT Sobral de Monte Agraço,EN Sobral de Monte Agraço,DE Sobral de Monte Agraço;PT;LI
+PT;PT-SRE;;SRE;PT municípios,EN municipalities,DE Gemeinden;PT Soure,EN Soure,DE Soure;PT;CO
+PT;PT-SSL;;SSL;PT municípios,EN municipalities,DE Gemeinden;PT Sousel,EN Sousel,DE Sousel;PT;PA
+PT;PT-TBU;;TBU;PT municípios,EN municipalities,DE Gemeinden;PT Tábua,EN Tábua,DE Tábua;PT;CO
+PT;PT-TBC;;TBC;PT municípios,EN municipalities,DE Gemeinden;PT Tabuaço,EN Tabuaço,DE Tabuaço;PT;VI
+PT;PT-TRC;;TRC;PT municípios,EN municipalities,DE Gemeinden;PT Tarouca,EN Tarouca,DE Tarouca;PT;VI
+PT;PT-TVR;;TVR;PT municípios,EN municipalities,DE Gemeinden;PT Tavira,EN Tavira,DE Tavira;PT;FA
+PT;PT-TBR;;TBR;PT municípios,EN municipalities,DE Gemeinden;PT Terras de Bouro,EN Terras de Bouro,DE Terras de Bouro;PT;BR
+PT;PT-TMR;;TMR;PT municípios,EN municipalities,DE Gemeinden;PT Tomar,EN Tomar,DE Tomar;PT;SA
+PT;PT-TND;;TND;PT municípios,EN municipalities,DE Gemeinden;PT Tondela,EN Tondela,DE Tondela;PT;VI
+PT;PT-TMC;;TMC;PT municípios,EN municipalities,DE Gemeinden;PT Torre de Moncorvo,EN Torre de Moncorvo,DE Torre de Moncorvo;PT;BA
+PT;PT-TNV;;TNV;PT municípios,EN municipalities,DE Gemeinden;PT Torres Novas,EN Torres Novas,DE Torres Novas;PT;SA
+PT;PT-TVD;;TVD;PT municípios,EN municipalities,DE Gemeinden;PT Torres Vedras,EN Torres Vedras,DE Torres Vedras;PT;LI
+PT;PT-TCS;;TCS;PT municípios,EN municipalities,DE Gemeinden;PT Trancoso,EN Trancoso,DE Trancoso;PT;GU
+PT;PT-TRF;;TRF;PT municípios,EN municipalities,DE Gemeinden;PT Trofa,EN Trofa,DE Trofa;PT;PO
+PT;PT-VGS;;VGS;PT municípios,EN municipalities,DE Gemeinden;PT Vagos,EN Vagos,DE Vagos;PT;AV
+PT;PT-VLC;;VLC;PT municípios,EN municipalities,DE Gemeinden;PT Vale de Cambra,EN Vale de Cambra,DE Vale de Cambra;PT;AV
+PT;PT-VLN;;VLN;PT municípios,EN municipalities,DE Gemeinden;PT Valença,EN Valença,DE Valença;PT;VC
+PT;PT-VLG;;VLG;PT municípios,EN municipalities,DE Gemeinden;PT Valongo,EN Valongo,DE Valongo;PT;PO
+PT;PT-VLP;;VLP;PT municípios,EN municipalities,DE Gemeinden;PT Valpaços,EN Valpaços,DE Valpaços;PT;VR
+PT;PT-VLS;;VLS;PT municípios,EN municipalities,DE Gemeinden;PT Velas,EN Velas,DE Velas;PT;AC
+PT;PT-VND;;VND;PT municípios,EN municipalities,DE Gemeinden;PT Vendas Novas,EN Vendas Novas,DE Vendas Novas;PT;EV
+PT;PT-VNT;;VNT;PT municípios,EN municipalities,DE Gemeinden;PT Viana do Alentejo,EN Viana do Alentejo,DE Viana do Alentejo;PT;EV
+PT;PT-VCT;;VCT;PT municípios,EN municipalities,DE Gemeinden;PT Viana do Castelo,EN Viana do Castelo,DE Viana do Castelo;PT;VC
+PT;PT-VDG;;VDG;PT municípios,EN municipalities,DE Gemeinden;PT Vidigueira,EN Vidigueira,DE Vidigueira;PT;BE
+PT;PT-VRM;;VRM;PT municípios,EN municipalities,DE Gemeinden;PT Vieira do Minho,EN Vieira do Minho,DE Vieira do Minho;PT;BR
+PT;PT-VLR;;VLR;PT municípios,EN municipalities,DE Gemeinden;PT Vila de Rei,EN Vila de Rei,DE Vila de Rei;PT;CB
+PT;PT-VBP;;VBP;PT municípios,EN municipalities,DE Gemeinden;PT Vila do Bispo,EN Vila do Bispo,DE Vila do Bispo;PT;FA
+PT;PT-VCD;;VCD;PT municípios,EN municipalities,DE Gemeinden;PT Vila do Conde,EN Vila do Conde,DE Vila do Conde;PT;PO
+PT;PT-VPT;;VPT;PT municípios,EN municipalities,DE Gemeinden;PT Vila do Porto,EN Vila do Porto,DE Vila do Porto;PT;AC
+PT;PT-VFL;;VFL;PT municípios,EN municipalities,DE Gemeinden;PT Vila Flor,EN Vila Flor,DE Vila Flor;PT;BA
+PT;PT-VFX;;VFX;PT municípios,EN municipalities,DE Gemeinden;PT Vila Franca de Xira,EN Vila Franca de Xira,DE Vila Franca de Xira;PT;LI
+PT;PT-VFC;;VFC;PT municípios,EN municipalities,DE Gemeinden;PT Vila Franca do Campo,EN Vila Franca do Campo,DE Vila Franca do Campo;PT;AC
+PT;PT-VNB;;VNB;PT municípios,EN municipalities,DE Gemeinden;PT Vila Nova da Barquinha,EN Vila Nova da Barquinha,DE Vila Nova da Barquinha;PT;SA
+PT;PT-VNC;;VNC;PT municípios,EN municipalities,DE Gemeinden;PT Vila Nova de Cerveira,EN Vila Nova de Cerveira,DE Vila Nova de Cerveira;PT;VC
+PT;PT-VNF;;VNF;PT municípios,EN municipalities,DE Gemeinden;PT Vila Nova de Famalicão,EN Vila Nova de Famalicão,DE Vila Nova de Famalicão;PT;BR
+PT;PT-VLF;;VLF;PT municípios,EN municipalities,DE Gemeinden;PT Vila Nova de Foz Côa,EN Vila Nova de Foz Côa,DE Vila Nova de Foz Côa;PT;GU
+PT;PT-VNG;;VNG;PT municípios,EN municipalities,DE Gemeinden;PT Vila Nova de Gaia,EN Vila Nova de Gaia,DE Vila Nova de Gaia;PT;PO
+PT;PT-VNP;;VNP;PT municípios,EN municipalities,DE Gemeinden;PT Vila Nova de Paiva,EN Vila Nova de Paiva,DE Vila Nova de Paiva;PT;VI
+PT;PT-PRS;;PRS;PT municípios,EN municipalities,DE Gemeinden;PT Vila Nova de Poiares,EN Vila Nova de Poiares,DE Vila Nova de Poiares;PT;CO
+PT;PT-VPA;;VPA;PT municípios,EN municipalities,DE Gemeinden;PT Vila Pouca de Aguiar,EN Vila Pouca de Aguiar,DE Vila Pouca de Aguiar;PT;VR
+PT;PT-VRL;;VRL;PT municípios,EN municipalities,DE Gemeinden;PT Vila Real,EN Vila Real,DE Vila Real;PT;VR
+PT;PT-VRS;;VRS;PT municípios,EN municipalities,DE Gemeinden;PT Vila Real de Santo António,EN Vila Real de Santo António,DE Vila Real de Santo António;PT;FA
+PT;PT-VVR;;VVR;PT municípios,EN municipalities,DE Gemeinden;PT Vila Velha de Ródão,EN Vila Velha de Ródão,DE Vila Velha de Ródão;PT;CB
+PT;PT-VVD;;VVD;PT municípios,EN municipalities,DE Gemeinden;PT Vila Verde,EN Vila Verde,DE Vila Verde;PT;BR
+PT;PT-VVC;;VVC;PT municípios,EN municipalities,DE Gemeinden;PT Vila Viçosa,EN Vila Viçosa,DE Vila Viçosa;PT;EV
+PT;PT-VMS;;VMS;PT municípios,EN municipalities,DE Gemeinden;PT Vimioso,EN Vimioso,DE Vimioso;PT;BA
+PT;PT-VNH;;VNH;PT municípios,EN municipalities,DE Gemeinden;PT Vinhais,EN Vinhais,DE Vinhais;PT;BA
+PT;PT-VIS;;VIS;PT municípios,EN municipalities,DE Gemeinden;PT Viseu,EN Viseu,DE Viseu;PT;VI
+PT;PT-VIZ;;VIZ;PT municípios,EN municipalities,DE Gemeinden;PT Vizela,EN Vizela,DE Vizela;PT;BR
+PT;PT-VZL;;VZL;PT municípios,EN municipalities,DE Gemeinden;PT Vouzela,EN Vouzela,DE Vouzela;PT;VI


### PR DESCRIPTION
This PR adds some initial data for Portugal:
* subdivisions: The 18 districts and 2 autonomous regions, as well as their 308 municipalities
* Public holidays on national and district level from 2020 to 2030
* Add entries to countries and languages

Unfortunately, the regional/municipal holidays seem to be quite scattered and I couldn't yet locate a single resource covering all of them. We'll also need an official resource for school holidays. But at least it's a start.