### PR TITLE
Fix Pfingstferien for Brandenburg

### DIFF
--- a/src/de/holidays/holidays.school.bb.csv
+++ b/src/de/holidays/holidays.school.bb.csv
@@ -43,7 +43,7 @@ de4ce3ad-0370-4580-9468-7fa6dad7bfa9;DE;2025-06-10;;School;DE Pfingstferien,EN P
 6dc2c4a3-709f-4ef3-af9e-34030f26ab70;DE;2026-02-02;2026-02-07;School;DE Winterferien,EN Winter holidays;BB
 f27e854e-e9f7-48d0-ac48-7675a327f29d;DE;2026-03-30;2026-04-10;School;DE Osterferien,EN Easter holidays;BB
 e9825bee-4d0b-41a5-8e61-36b01fb2c635;DE;2026-05-15;;School;DE Variabler Ferientag,EN Variable holiday;BB
-5543e812-5959-4533-b493-138952caceee;DE;2025-05-26;;School;DE Pfingstferien,EN Pentecost holiday;BB
+5543e812-5959-4533-b493-138952caceee;DE;2026-05-26;;School;DE Pfingstferien,EN Pentecost holiday;BB
 328c986c-a822-41e1-9eb1-6f6c9d0a2504;DE;2026-07-09;2026-08-22;School;DE Sommerferien,EN Summer holidays;BB
 37b0ebd1-bccb-46c8-ada9-2d71899503dd;DE;2026-10-19;2026-10-30;School;DE Herbstferien,EN Autumn holidays;BB
 6153428a-b18e-432b-8c93-e364ac63e951;DE;2026-12-23;2027-01-02;School;DE Weihnachtsferien,EN Christmas holidays;BB
@@ -63,7 +63,6 @@ c26f5b58-fbaf-4c52-9dea-472fdeb86360;DE;2028-10-30;;School;DE Variabler Ferienta
 430c58a6-5885-439d-af46-d4f4e7f43010;DE;2028-12-22;2029-01-02;School;DE Weihnachtsferien,EN Christmas holidays;BB
 78f66f3f-9dd8-4957-8db2-22dfa14a4c8d;DE;2029-01-29;2029-02-03;School;DE Winterferien,EN Winter holidays;BB
 08bd12b4-575a-4fd2-92e3-965524499aad;DE;2029-03-26;2029-04-06;School;DE Osterferien,EN Easter holidays;BB
-8908d59a-f938-4e45-b311-6a08d9b203eb;DE;2029-04-30;;School;DE Pfingstferien,EN Pentecost holiday;BB
 d9287911-7a30-45b8-a77f-a6091ab64c35;DE;2029-05-11;;School;DE Variabler Ferientag,EN Variable holiday;BB
 201c939f-caed-457d-bfec-dfdff6974d96;DE;2029-05-22;;School;DE Pfingstferien,EN Pentecost holiday;BB
 41f7bd25-7151-407c-b99c-60de382cba3f;DE;2029-06-28;2029-08-11;School;DE Sommerferien,EN Summer holidays;BB


### PR DESCRIPTION
Source is the same as in the README:
https://mbjs.brandenburg.de/bildung/weitere-themen/schulferien-brandenburg.html