### PR TITLE
Add new AT school holidays

### DIFF
--- a/src/at/holidays/holidays.school.csv
+++ b/src/at/holidays/holidays.school.csv
@@ -1,4 +1,4 @@
-﻿Id;Country;StartDate;EndDate;Type;RegionalScope;Name;Subdivisions;Comment
+Id;Country;StartDate;EndDate;Type;RegionalScope;Name;Subdivisions;Comment
 26f6b53b-b5a8-46d2-8e85-cf99a3f9e7ac;AT;2019-12-23;2020-01-06;School;National;DE Weihnachtsferien,EN Christmas Holidays;;
 716ada6f-b2bc-4512-a11d-d2d76a82b915;AT;2020-02-03;2020-02-08;School;Regional;DE Semesterferien,EN Semester Holidays;NÖ,WI;
 518a3568-c37c-4102-bc20-1f6f3f5418a7;AT;2020-02-10;2020-02-15;School;Regional;DE Semesterferien,EN Semester Holidays;BL,KÄ,SB,TI,VA;
@@ -76,3 +76,15 @@ b3f77f3c-f4ba-4392-8552-01c2e6d7a27c;AT;2024-11-15;;School;Regional;DE St. Leopo
 e3d0a97e-de38-4e5a-bdf0-c8c1ba7a6119;AT;2024-12-24;2025-01-06;School;National;DE Weihnachtsferien,EN Christmas Holidays;;
 d97aa6f6-df49-45cd-9d3e-c030946169ce;AT;2025-04-12;2025-04-21;School;National;DE Osterferien,EN Easter Holidays;;
 8ac56699-10ec-47d3-8e9c-995da7730fd8;AT;2025-06-07;2025-06-09;School;National;DE Pfingstferien,EN Pentecost Holidays;;
+f819bb21-50a9-41da-8588-0d92b176e858;AT;2025-02-03;2025-02-08;School;Regional;DE Semesterferien,EN Semester Holidays;NÖ,WI;
+9346b0f5-74b0-489b-b719-fba6d87738df;AT;2025-02-10;2025-02-15;School;Regional;DE Semesterferien,EN Semester Holidays;BL,KÄ,SB,TI,VA;
+c50dd649-e285-45f9-b730-b9f6d49fa459;AT;2025-02-17;2025-02-22;School;Regional;DE Semesterferien,EN Semester Holidays;OÖ,SM;
+76f3fc33-8afa-4e97-9f48-df0a109bcf8e;AT;2025-10-27;2025-10-31;School;National;DE Herbstferien,EN Automn Holidays;;
+7a034d2c-9044-44d6-956f-d9f6575480d0;AT;2025-12-24;2026-01-06;School;National;DE Weihnachtsferien,EN Christmas Holidays;;
+fb8316b8-b3ef-43b9-8927-5543582ababb;AT;2026-02-02;2026-02-07;School;Regional;DE Semesterferien,EN Semester Holidays;NÖ,WI;
+ae990287-bde4-47be-9860-0f601e7adf45;AT;2026-02-09;2026-02-14;School;Regional;DE Semesterferien,EN Semester Holidays;BL,KÄ,SB,TI,VA;
+0e524064-e102-4524-9d20-d33b9fcd1eb5;AT;2026-02-16;2026-02-21;School;Regional;DE Semesterferien,EN Semester Holidays;OÖ,SM;
+fd7ada74-ef0e-4713-b8d3-3227d1372061;AT;2026-03-28;2026-04-06;School;National;DE Osterferien,EN Easter Holidays;;
+65ce3d86-9eda-49d1-bef1-4c7816c1dc38;AT;2026-05-23;2026-05-25;School;National;DE Pfingstferien,EN Pentecost Holidays;;
+23a1b4df-9a6f-42d3-87b9-6d3eb51992cf;AT;2026-07-04;2026-09-06;School;Regional;DE Sommerferien,EN Summer Holidays;BL,NÖ,WI;
+4414a62a-ea15-44ab-8105-1bb0db49187d;AT;2026-07-11;2026-09-13;School;Regional;DE Sommerferien,EN Summer Holidays;KÄ,OÖ,SB,SM,TI,VA;


### PR DESCRIPTION
Semester holidays 2025 were missing as well as all 2025/2026 entries taken from https://www.bmbwf.gv.at/Themen/schule/schulpraxis/termine/ferientermine_25_26.html

uuids created with https://www.guidgenerator.com/

First line change is obviously due to whitespace cleanup from editor.