### PR TITLE
Added missing semicolon at the end of  it subdivision IT Trentino-Alto Adige

### DIFF
--- a/src/it/subdivisions.csv
+++ b/src/it/subdivisions.csv
@@ -17,7 +17,7 @@ IT;IT-VE;IT-34;VE;IT regione,EN region,DE Region;IT Veneto,EN Veneto,DE Venetien
 IT;IT-FV;IT-36;FV;IT regione autonoma,EN autonomous region,DE autonome Region;IT Friuli Venezia Giulia,EN Friuli Venezia Giulia,DE Friaul-Julisch Venetien;IT;
 IT;IT-SA;IT-88;SA;IT regione autonoma,EN autonomous region,DE autonome Region;IT Sardegna,EN Sardinia,DE Sardinien;IT;
 IT;IT-SI;IT-82;SI;IT regione autonoma,EN autonomous region,DE autonome Region;IT Sicilia,EN Sicily,DE Sizilien;IT;
-IT;IT-TR;IT-32;TR;IT regione autonoma,EN autonomous region,DE autonome Region;IT Trentino-Alto Adige,EN Trentino-Alto Adige,DE Trentino-Südtirol;IT,DE
+IT;IT-TR;IT-32;TR;IT regione autonoma,EN autonomous region,DE autonome Region;IT Trentino-Alto Adige,EN Trentino-Alto Adige,DE Trentino-Südtirol;IT,DE;
 IT;IT-VA;IT-23;VA;IT regione autonoma,EN autonomous region,DE autonome Region;IT Valle d'Aosta,FR Val d'Aoste,EN Aosta Valley,DE Aostatal;IT,FR;
 IT;IT-PI-AL;IT-AL;PI-AL;IT province,EN province,DE Provinz;IT Alessandria,EN Alessandria,DE Alessandria;IT;PI
 IT;IT-MA-AN;IT-AN;MA-AN;IT province,EN province,DE Provinz;IT Ancona,EN Ancona,DE Ancona;IT;MA


### PR DESCRIPTION
Added missing semicolon at the end of IT Trentino-Alto Adige to separate from Parent