### PR TITLE
Added school LU holidays for school year 2026/2027

### DIFF
--- a/src/lu/holidays/holidays.school.csv
+++ b/src/lu/holidays/holidays.school.csv
@@ -40,3 +40,9 @@ a9416d19-87d9-4610-a101-c4f9f6ea21d8;LU;2026-02-14;2026-02-22;School;National;FR
 4a313b71-0e0c-4a12-bc92-9b854069e319;LU;2026-03-28;2026-04-12;School;National;FR Vacances de Pâques,DE Osterferien,LB Ouschtervakanz,EN Easter Holidays;
 f2c93ae1-14c8-460f-a694-598b2574e62a;LU;2026-05-23;2026-05-31;School;National;FR Congé de la Pentecôte,DE Pfingstferien,LB Päischtfeierdeeg,EN Pentecost Holidays;
 471cedeb-bec6-4aa3-8ab7-64119ed7a25c;LU;2026-07-16;2026-09-14;School;National;FR Vacances d’été,DE Sommerferien,LB Grouss Vakanz,EN Summer Holidays;
+2fc0573c-2b47-4e67-80ff-f04b4a4714fb;LU;2026-10-31;2026-11-08;School;National;FR Congé de la Toussaint,DE Allerheiligenferien,LB Allerhellgen Vakanz,EN All Saints Day Holidays;
+7518b09c-10d2-4291-aa01-37d09eb028c7;LU;2026-12-19;2027-01-03;School;National;FR Vacances de Noël,DE Weihnachtsferien,LB Chrëschtdag Vakanz,EN Christmas Holidays;
+b0c2e75e-1a9a-44fb-865c-ad55f1bab739;LU;2027-02-06;2027-02-14;School;National;FR Congé de Carnaval,DE Karnevalsferien,LB Karneval Vakanz,EN Carnival Holidays;
+bed67dd3-fd43-4c8a-a737-1fab2dcad86b;LU;2027-03-27;2027-04-11;School;National;FR Vacances de Pâques,DE Osterferien,LB Ouschtervakanz,EN Easter Holidays;
+c89c917c-c1eb-478d-955a-0cb25584fa2f;LU;2027-05-29;2027-06-06;School;National;FR Congé de la Pentecôte,DE Pfingstferien,LB Päischtfeierdeeg,EN Pentecost Holidays;
+8673d187-f415-41d4-8f9a-8ae8bd48b446;LU;2027-07-16;2027-09-14;School;National;FR Vacances d’été,DE Sommerferien,LB Grouss Vakanz,EN Summer Holidays;


### PR DESCRIPTION
Added school LU holidays for school year 2026/2027 based on https://men.public.lu/en/vacances-scolaires.html