### PR TITLE
Bulgarian holidays

### DIFF
--- a/src/bg/holidays/holidays.public.csv
+++ b/src/bg/holidays/holidays.public.csv
@@ -12,7 +12,6 @@ bda59102-2939-4335-8211-9080e12dcaf3;BG;2020-05-25;;Public;National;BG Ден н
 f4c88fdc-e90c-4199-96e0-486345a3e1fa;BG;2020-09-06;;Public;National;BG Ден на Съединението,DE Tag der Wiedervereinigung,EN Unification Day;
 a15b76e3-9574-428e-8cb6-02584af298e1;BG;2020-09-07;;Public;National;BG Ден на Съединението,DE Tag der Wiedervereinigung,EN Unification Day (Observed);
 41f43e26-e387-4363-a4fd-b9e6d90c22c6;BG;2020-09-22;;Public;National;BG Ден на независимостта на България,DE Unabhängigkeitstag,EN Independence Day;
-772b239c-ccd3-49ac-b426-a9c7bdcc57bd;BG;2020-11-01;;Public;National;BG Ден на народните будители,DE Tag der bulgarischen Vordenker der Aufklärung,EN Day of the Bulgarian Enlighteners;BG неприсъствен за всички учебни заведения,DE Feiertag für alle Bildungseinrichtungen,EN Holiday for all educational institutions
 1f1fd7ff-cee3-43c9-867f-18e67ce7b6e3;BG;2020-12-24;;Public;National;BG Бъдни вечер,DE Heilig Abend,EN Christmas Eve;
 e56aa60d-a084-470d-9cd9-03af29d17966;BG;2020-12-25;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
 a948dcf5-5210-4a76-bd21-41e971eab186;BG;2020-12-26;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
@@ -29,7 +28,6 @@ cb82f307-bae0-4552-b01c-4aba8ee95df5;BG;2021-05-06;;Public;National;BG Герг�
 361dfc2f-60c7-45da-ad02-a16632cea240;BG;2021-05-24;;Public;National;BG Ден на Българската просвета и култура и на славянската писменост,DE Tag der bulgarischen Aufklärung und Kultur, Tag der slawischen Literatur,EN Bulgarian Education and Culture, and Slavic Script Day;
 1925d151-8d31-4fe8-8582-fa402af25ccd;BG;2021-09-06;;Public;National;BG Ден на Съединението,DE Tag der Wiedervereinigung,EN Unification Day;
 0b09ab04-a5af-48ab-851f-91fe6bea757b;BG;2021-09-22;;Public;National;BG Ден на независимостта на България,DE Unabhängigkeitstag,EN Independence Day;
-84a5d817-ed56-4d71-b3e0-2bfa41ac5729;BG;2021-11-01;;Public;National;BG Ден на народните будители,DE Tag der bulgarischen Vordenker der Aufklärung,EN Day of the Bulgarian Enlighteners;BG неприсъствен за всички учебни заведения,DE Feiertag für alle Bildungseinrichtungen,EN Holiday for all educational institutions
 8a524219-2544-4f73-91e6-24e357d32490;BG;2021-12-24;;Public;National;BG Бъдни вечер,DE Heilig Abend,EN Christmas Eve;
 3085e2d0-ab79-4f83-bdf7-bbc0ea4fbcf3;BG;2021-12-25;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
 87f568a4-98e2-489f-bdba-bdad15944244;BG;2021-12-26;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
@@ -47,7 +45,6 @@ cdbe57b1-73ab-4a8e-8367-15b2b24d346a;BG;2022-05-01;;Public;National;BG Ден н
 73c5c483-54b6-4db5-935b-76ac5bf04bae;BG;2022-05-24;;Public;National;BG Ден на Българската просвета и култура и на славянската писменост,DE Tag der bulgarischen Aufklärung und Kultur, Tag der slawischen Literatur,EN Bulgarian Education and Culture, and Slavic Script Day;
 ad91f7e0-a7df-4516-9dbe-e138319fe287;BG;2022-09-06;;Public;National;BG Ден на Съединението,DE Tag der Wiedervereinigung,EN Unification Day;
 4a16bbec-d882-432c-b428-ea65ac630def;BG;2022-09-22;;Public;National;BG Ден на независимостта на България,DE Unabhängigkeitstag,EN Independence Day;
-010d566a-725d-402b-8eb7-3562c7758a43;BG;2022-11-01;;Public;National;BG Ден на народните будители,DE Tag der bulgarischen Vordenker der Aufklärung,EN Day of the Bulgarian Enlighteners;BG неприсъствен за всички учебни заведения,DE Feiertag für alle Bildungseinrichtungen,EN Holiday for all educational institutions
 229d386e-529f-48eb-83f1-6963c90d09a4;BG;2022-12-24;;Public;National;BG Бъдни вечер,DE Heilig Abend,EN Christmas Eve;
 7b226987-9f12-45b9-acdc-e68e1a65464d;BG;2022-12-25;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
 70190658-cf42-4634-8e61-2b8cc49fa24d;BG;2022-12-26;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
@@ -66,7 +63,6 @@ ce8e8654-228b-49a3-9ff2-db4589acffdf;BG;2023-05-06;;Public;National;BG Герг�
 67c35649-78b3-4b8a-96dd-a885500720a9;BG;2023-05-24;;Public;National;BG Ден на Българската просвета и култура и на славянската писменост,DE Tag der bulgarischen Aufklärung und Kultur, Tag der slawischen Literatur,EN Bulgarian Education and Culture, and Slavic Script Day;
 3ef39d14-47fb-479e-95b8-2e8e796913fa;BG;2023-09-06;;Public;National;BG Ден на Съединението,DE Tag der Wiedervereinigung,EN Unification Day;
 0a676519-4cdf-41df-b612-e531dd47d85c;BG;2023-09-22;;Public;National;BG Ден на независимостта на България,DE Unabhängigkeitstag,EN Independence Day;
-ddd1b2ae-8685-4b11-9ad5-dbaa4ab7b46f;BG;2023-11-01;;Public;National;BG Ден на народните будители,DE Tag der bulgarischen Vordenker der Aufklärung,EN Day of the Bulgarian Enlighteners;BG неприсъствен за всички учебни заведения,DE Feiertag für alle Bildungseinrichtungen,EN Holiday for all educational institutions
 0f25cc15-87ed-4ff2-8f0a-f6e21d3e8f8c;BG;2023-12-24;;Public;National;BG Бъдни вечер,DE Heilig Abend,EN Christmas Eve;
 6fb193a1-1941-461c-b8fc-5f30de0b6bdb;BG;2023-12-25;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
 ffd36b6d-add7-4960-b913-e3df4892e2c5;BG;2023-12-26;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
@@ -84,7 +80,6 @@ a1ec80c0-a39f-45e3-9c3b-e7f2a735d1d3;BG;2024-05-06;;Public;National;BG Вели�
 5458669c-743c-4692-b495-45e78de133fe;BG;2024-09-06;;Public;National;BG Ден на Съединението,DE Tag der Wiedervereinigung,EN Unification Day;
 579bf9a5-e2fb-446c-9501-58fcab377de1;BG;2024-09-22;;Public;National;BG Ден на независимостта на България,DE Unabhängigkeitstag,EN Independence Day;
 e850bd5d-bc66-4c18-ad17-326a21964e2a;BG;2024-09-23;;Public;National;BG Ден на независимостта на България,DE Unabhängigkeitstag,EN Independence Day (Observed);
-7f8ad179-da3c-4afc-bcf0-c2a9d1c69c1c;BG;2024-11-01;;Public;National;BG Ден на народните будители,DE Tag der bulgarischen Vordenker der Aufklärung,EN Day of the Bulgarian Enlighteners;BG неприсъствен за всички учебни заведения,DE Feiertag für alle Bildungseinrichtungen,EN Holiday for all educational institutions
 ba55152c-92c8-486f-87aa-7351033209f4;BG;2024-12-24;;Public;National;BG Бъдни вечер,DE Heilig Abend,EN Christmas Eve;
 fb9a73d0-2899-414c-8e04-74057ac1a6a6;BG;2024-12-25;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
 b13d3f57-ff46-4bcb-8208-07643f5ff6e1;BG;2024-12-26;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
@@ -101,7 +96,6 @@ f1587af9-e78c-4b68-b410-2a3bf9766c2a;BG;2025-05-26;;Public;National;BG Ден н
 eb120d0a-9ae9-4ee7-87fb-a7784e116d4d;BG;2025-09-06;;Public;National;BG Ден на Съединението,DE Tag der Wiedervereinigung,EN Unification Day;
 b74a01ae-f0da-4ee0-a10f-b3d4a6195481;BG;2025-09-08;;Public;National;BG Ден на Съединението,DE Tag der Wiedervereinigung,EN Unification Day (Observed);
 e87f67a7-112e-448c-963a-4826545f5f87;BG;2025-09-22;;Public;National;BG Ден на независимостта на България,DE Unabhängigkeitstag,EN Independence Day;
-8be43fe0-0133-4e4f-adbc-beab1ea70dc1;BG;2025-11-01;;Public;National;BG Ден на народните будители,DE Tag der bulgarischen Vordenker der Aufklärung,EN Day of the Bulgarian Enlighteners;BG неприсъствен за всички учебни заведения,DE Feiertag für alle Bildungseinrichtungen,EN Holiday for all educational institutions
 736de274-5916-4b93-8078-963a0b1bee7b;BG;2025-12-24;;Public;National;BG Бъдни вечер,DE Heilig Abend,EN Christmas Eve;
 2cad04d7-46b3-4c15-a337-e662331c187d;BG;2025-12-25;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
 2ff127be-92bc-4c48-8202-65ad6ae8a889;BG;2025-12-26;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
@@ -118,7 +112,6 @@ ba725ef4-0ca1-4c10-813b-30db786d2a08;BG;2026-05-25;;Public;National;BG Ден н
 85020b7d-0ff6-4a56-88e2-67959cabf90a;BG;2026-09-06;;Public;National;BG Ден на Съединението,DE Tag der Wiedervereinigung,EN Unification Day;
 0a8cc497-42a2-4689-beb0-a8ea789e24f1;BG;2026-09-07;;Public;National;BG Ден на Съединението,DE Tag der Wiedervereinigung,EN Unification Day (Observed);
 b127599c-09bf-47df-92eb-c20234f8039d;BG;2026-09-22;;Public;National;BG Ден на независимостта на България,DE Unabhängigkeitstag,EN Independence Day;
-42bb0242-4826-4bb9-824f-a858611cd102;BG;2026-11-01;;Public;National;BG Ден на народните будители,DE Tag der bulgarischen Vordenker der Aufklärung,EN Day of the Bulgarian Enlighteners;BG неприсъствен за всички учебни заведения,DE Feiertag für alle Bildungseinrichtungen,EN Holiday for all educational institutions
 4fcbaf08-3f11-4b26-92d4-6e5bbd8b5909;BG;2026-12-24;;Public;National;BG Бъдни вечер,DE Heilig Abend,EN Christmas Eve;
 ddc88f1a-bebe-46cf-9e3e-049368ce8c92;BG;2026-12-25;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
 6e44e8f4-3704-439d-b63f-8054dc798b34;BG;2026-12-26;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
@@ -134,7 +127,6 @@ c6f94742-9ccc-490a-8692-1a8de90ab7b9;BG;2027-05-06;;Public;National;BG Герг�
 a109219d-3417-4ed5-a934-9b215647e923;BG;2027-05-24;;Public;National;BG Ден на Българската просвета и култура и на славянската писменост,DE Tag der bulgarischen Aufklärung und Kultur, Tag der slawischen Literatur,EN Bulgarian Education and Culture, and Slavic Script Day;
 57b7cd72-58c7-4b18-908c-cee76725f417;BG;2027-09-06;;Public;National;BG Ден на Съединението,DE Tag der Wiedervereinigung,EN Unification Day;
 e6e70e63-3cdc-4cc8-99d9-81c114ea27ca;BG;2027-09-22;;Public;National;BG Ден на независимостта на България,DE Unabhängigkeitstag,EN Independence Day;
-52c396cd-be50-4330-9760-6eb067855c6d;BG;2027-11-01;;Public;National;BG Ден на народните будители,DE Tag der bulgarischen Vordenker der Aufklärung,EN Day of the Bulgarian Enlighteners;BG неприсъствен за всички учебни заведения,DE Feiertag für alle Bildungseinrichtungen,EN Holiday for all educational institutions
 8273c951-7aec-429e-8847-cd9b516a5bb6;BG;2027-12-24;;Public;National;BG Бъдни вечер,DE Heilig Abend,EN Christmas Eve;
 d8fbfcf9-8ed3-4f3a-98b8-1da6c63cc943;BG;2027-12-25;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
 f10c0452-ccac-4dc2-87c1-302e9d15aee7;BG;2027-12-26;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
@@ -149,7 +141,6 @@ c933d88a-3e61-4748-8edd-3867a5f07617;BG;2028-05-06;;Public;National;BG Герг�
 76435805-3e6f-4313-a64e-be7fe32c6881;BG;2028-05-24;;Public;National;BG Ден на Българската просвета и култура и на славянската писменост,DE Tag der bulgarischen Aufklärung und Kultur, Tag der slawischen Literatur,EN Bulgarian Education and Culture, and Slavic Script Day;
 9c3143e0-9302-4dbc-9188-8b38dc539ea9;BG;2028-09-06;;Public;National;BG Ден на Съединението,DE Tag der Wiedervereinigung,EN Unification Day;
 5928800f-de8d-4971-a743-6923e100dbb0;BG;2028-09-22;;Public;National;BG Ден на независимостта на България,DE Unabhängigkeitstag,EN Independence Day;
-b73e1b0f-f33c-4c5c-aa6b-45cb1c0042d0;BG;2028-11-01;;Public;National;BG Ден на народните будители,DE Tag der bulgarischen Vordenker der Aufklärung,EN Day of the Bulgarian Enlighteners;BG неприсъствен за всички учебни заведения,DE Feiertag für alle Bildungseinrichtungen,EN Holiday for all educational institutions
 58615a09-84c5-4e99-bdd5-bbd24c428a5a;BG;2028-12-24;;Public;National;BG Бъдни вечер,DE Heilig Abend,EN Christmas Eve;
 4bcc37f7-7888-4c0b-aa88-0daa9d10537e;BG;2028-12-25;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
 601ca98d-3031-434f-a3cb-93034e19924d;BG;2028-12-26;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
@@ -164,7 +155,6 @@ c54395a0-91db-4798-bc21-53da5f04d1ea;BG;2029-05-06;;Public;National;BG Герг�
 06dae001-c250-49a4-adf1-9cf65ce1a40d;BG;2029-05-24;;Public;National;BG Ден на Българската просвета и култура и на славянската писменост,DE Tag der bulgarischen Aufklärung und Kultur, Tag der slawischen Literatur,EN Bulgarian Education and Culture, and Slavic Script Day;
 3d45b252-e241-4a0a-bbbb-8ae2e0fb72f6;BG;2029-09-06;;Public;National;BG Ден на Съединението,DE Tag der Wiedervereinigung,EN Unification Day;
 83934783-12e3-493b-ab64-3cdd64530aa1;BG;2029-09-22;;Public;National;BG Ден на независимостта на България,DE Unabhängigkeitstag,EN Independence Day;
-a0d8c237-ca85-46cf-8dcd-c14a56da0176;BG;2029-11-01;;Public;National;BG Ден на народните будители,DE Tag der bulgarischen Vordenker der Aufklärung,EN Day of the Bulgarian Enlighteners;BG неприсъствен за всички учебни заведения,DE Feiertag für alle Bildungseinrichtungen,EN Holiday for all educational institutions
 bd005b47-48b5-4b79-b6ad-645195853751;BG;2029-12-24;;Public;National;BG Бъдни вечер,DE Heilig Abend,EN Christmas Eve;
 b9f61bb3-1004-47c9-8186-4ac24c1de75c;BG;2029-12-25;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
 b8a7a3e6-6b07-48e1-a043-4ed48b7a7ad3;BG;2029-12-26;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
@@ -179,7 +169,6 @@ d762ce67-906e-45d2-9958-8a2c58288457;BG;2030-05-06;;Public;National;BG Герг�
 a9a7675a-ad54-4026-aa95-ad06444f9dbf;BG;2030-05-24;;Public;National;BG Ден на Българската просвета и култура и на славянската писменост,DE Tag der bulgarischen Aufklärung und Kultur, Tag der slawischen Literatur,EN Bulgarian Education and Culture, and Slavic Script Day;
 364e8531-8ac0-491f-93d0-815906f82f42;BG;2030-09-06;;Public;National;BG Ден на Съединението,DE Tag der Wiedervereinigung,EN Unification Day;
 36b50a5c-8e1d-482c-b3bd-14c28527b601;BG;2030-09-22;;Public;National;BG Ден на независимостта на България,DE Unabhängigkeitstag,EN Independence Day;
-b960a10c-59c3-47a5-8480-5d52fcc1d7ee;BG;2030-11-01;;Public;National;BG Ден на народните будители,DE Tag der bulgarischen Vordenker der Aufklärung,EN Day of the Bulgarian Enlighteners;BG неприсъствен за всички учебни заведения,DE Feiertag für alle Bildungseinrichtungen,EN Holiday for all educational institutions
 eab72a4d-5142-424d-aad2-c7f2776be34c;BG;2030-12-24;;Public;National;BG Бъдни вечер,DE Heilig Abend,EN Christmas Eve;
 3af7d712-0508-4e34-9fba-38359d910bb7;BG;2030-12-25;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
 5223d0b1-6292-4824-9d9d-a9d4bb1f6b87;BG;2030-12-26;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;


### PR DESCRIPTION
When a holiday is on the weekend, it is observed on the Monday or Tuesday instead. Holidays from 2020 to 2026 are changed and https://почивнидни.com/ is used as a source.

In addition, "Day of the Bulgarian Enlighteners" is observed only by schools and the education system, so it's not relevant to the general population.