### PR TITLE
Add FR school holidays 2026/2027

### DIFF
--- a/src/fr/holidays/holidays.school.csv
+++ b/src/fr/holidays/holidays.school.csv
@@ -102,3 +102,14 @@ c7eb1e77-104d-4173-b2a1-0cf1ff9b6f91;FR;2026-04-18;2026-05-04;School;Regional;FR
 1937bfbb-5bee-4cb0-b85d-cab0c5e3adc2;FR;2026-04-26;2026-05-11;School;Regional;FR Vacances de Pâques,DE Osterferien,EN Easter holidays;YT
 94845932-7265-4aad-952c-232ee2e8a002;FR;2026-05-02;2026-05-17;School;Regional;FR Vacances après quatrième période,DE Urlaub nach der vierten Periode,EN Holidays after fourth period;RU
 25265659-8d52-4b19-8edd-f321f4688cbf;FR;2026-07-04;;EndOfLessons;Regional;FR Fin des cours,DE Unterrichtsende,EN End of lessons;ZA,AR,BF,NA,SP,ZB,BT,CV,GE,HF,NO,PC,PL,ZC,IF,OC,CO,GP,BL,MF,MQ,GY,RU,YT
+bb33e004-bbd1-498f-8ede-c16846238477;FR;2026-07-04;2026-08-31;School;Regional;FR Vacances d'été,DE Sommerferien,EN Summer Holidays;ZA,AR,BF,NA,ZB,BT,CV,GE,HF,NO,PC,PL,ZC,IF,OC,CO
+1eab9f70-49bf-47b9-89bd-2f428712b771;FR;2026-10-17;2026-11-01;School;Regional;FR Vacances de la Toussaint,DE Allerheiligenferien,EN All Saints Holidays;ZA,AR,BF,NA,ZB,BT,CV,GE,HF,NO,PC,PL,ZC,IF,OC,CO
+5d81c270-a6b1-4dbd-93b1-78d43c59732b;FR;2026-12-19;2027-01-03;School;Regional;FR Vacances de Noël,DE Weihnachtsferien,EN Christmas Holidays;ZA,AR,BF,NA,ZB,BT,CV,GE,HF,NO,PC,PL,ZC,IF,OC,CO
+fc6714a0-5680-4869-ae78-6ab02a3d4ced;FR;2027-02-13;2027-02-28;School;Regional;FR Vacances d'hiver,DE Winterferien,EN Winter Holidays;ZA,AR,BF,NA
+12dec4c1-cfb1-49dc-837a-a18ba50283c9;FR;2027-02-20;2027-03-07;School;Regional;FR Vacances d'hiver,DE Winterferien,EN Winter Holidays;ZB,BT,CV,GE,HF,NO,PC,PL
+4eff0ec8-9f93-455d-98fc-44738ffe59c3;FR;2027-02-06;2027-02-21;School;Regional;FR Vacances d'hiver,DE Winterferien,EN Winter Holidays;ZC,IF,OC
+7d0c13be-c980-44cf-8b64-356f3a77565e;FR;2027-04-10;2027-04-25;School;Regional;FR Vacances de printemps,DE Frühjahrsferien,EN Spring Holidays;ZA,AR,BF,NA
+387330fc-6c9c-4912-8f14-a51656b00129;FR;2027-04-17;2027-05-02;School;Regional;FR Vacances de printemps,DE Frühjahrsferien,EN Spring Holidays;ZB,BT,CV,GE,HF,NO,PC,PL
+535af364-727e-49b7-8e5b-a465aa2e90aa;FR;2027-04-03;2027-04-18;School;Regional;FR Vacances de printemps,DE Frühjahrsferien,EN Spring Holidays;ZC,IF,OC
+8f659095-bec1-4ba1-b63d-d05bf521bf3f;FR;2027-05-06;2027-05-09;School;Regional;FR Pont de l'Ascension,DE Brückentage zu Christi Himmelfahrt,EN Ascension Bridge;ZA,AR,BF,NA,ZB,BT,CV,GE,HF,NO,PC,PL,ZC,IF,OC,CO
+c09411e8-4aeb-4010-af91-22813b88b2c6;FR;2027-07-03;2027-08-31;School;Regional;FR Vacances d'été,DE Sommerferien,EN Summer Holidays;ZA,AR,BF,NA,ZB,BT,CV,GE,HF,NO,PC,PL,ZC,IF,OC,CO


### PR DESCRIPTION
Add FR school holidays 2026/2027

Sources:
- https://www.education.gouv.fr/calendrier-scolaire-100148
- https://www.vacances-scolaires-education.fr/images/calendrier-scolaire/2026-2027/calendrier-scolaire-2026-2027-avec-jours-feries.jpg

![calendrier-scolaire-2026-2027-avec-jours-feries](https://github.com/user-attachments/assets/064e5e3c-c6ca-4f7f-a5b1-2feae4b253c5)

<img width="962" height="680" alt="grafik" src="https://github.com/user-attachments/assets/d75fccfa-0ae4-4d58-ab9d-c34dbd0cc245" />

