### PR TITLE
Added Euro Adoption Days (2 days 31.12.2025 and 02.01.2026)

### DIFF
--- a/src/bg/holidays/holidays.public.csv
+++ b/src/bg/holidays/holidays.public.csv
@@ -99,9 +99,9 @@ e87f67a7-112e-448c-963a-4826545f5f87;BG;2025-09-22;;Public;National;BG Ден н
 736de274-5916-4b93-8078-963a0b1bee7b;BG;2025-12-24;;Public;National;BG Бъдни вечер,DE Heilig Abend,EN Christmas Eve;
 2cad04d7-46b3-4c15-a337-e662331c187d;BG;2025-12-25;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
 2ff127be-92bc-4c48-8202-65ad6ae8a889;BG;2025-12-26;;Public;National;BG Рождество Христово,DE Weihnachten,EN Christmas Day;
-96fbf7db-fdaa-4361-8978-5bf9b2239642;BG;2025-12-31;;Public;National;BG Ден на приемане на еврото,DE Tag der Euro-Einführung, EN Euro Adoption Day;
+96fbf7db-fdaa-4361-8978-5bf9b2239642;BG;2025-12-31;;Public;National;BG Ден на приемане на еврото,DE Tag der Euro-Einführung,EN Euro Adoption Day;
 07e6c1db-5c9b-4692-b99a-9af69a858ee0;BG;2026-01-01;;Public;National;BG Нова година,DE Neujahr,EN New Year's Day;
-6307a528-a066-4f20-b248-9aae23cdc495;BG;2025-01-02;;Public;National;BG Ден на приемане на еврото,DE Tag der Euro-Einführung, EN Euro Adoption Day;
+6307a528-a066-4f20-b248-9aae23cdc495;BG;2025-01-02;;Public;National;BG Ден на приемане на еврото,DE Tag der Euro-Einführung,EN Euro Adoption Day;
 5d0fd369-1574-411f-a129-44e65e01d5eb;BG;2026-03-03;;Public;National;BG Ден на Освобождението на България от османско иго,DE Tag der Befreiung Bulgariens von der osmanischen Herrschaft,EN Bulgaria’s Liberation from the Ottoman Empire;
 9ce73a35-e70c-43e8-8f57-4e1bc0383ca9;BG;2026-04-10;;Public;National;BG Разпети петък,DE Karfreitag,EN Good Friday;
 b7af5e27-dd1a-48ea-a7d1-0677b8689256;BG;2026-04-11;;Public;National;BG Велика събота,DE Karsamstag,EN Holy Saturday;


### PR DESCRIPTION
One-off event decision by the Bulgarian Government

https://sofiaglobe.com/2025/11/19/bulgaria-extends-new-year-public-holidays-because-of-transition-to-euro/