### PR TITLE
Remove duplicated easter holiday for de-mv-bbs

### DIFF
--- a/src/de/holidays/holidays.school.mv.csv
+++ b/src/de/holidays/holidays.school.mv.csv
@@ -119,7 +119,6 @@ da80c851-b104-4096-925b-abcf83638b07;DE;2028-02-05;2028-02-12;School;Regional;DE
 93ab0ef1-45e5-4e91-8546-4f660cc023f2;DE;2028-03-09;;School;Regional;DE Zusätzlicher Ferientag,EN Additional holiday;MV-BBS
 2e1685cc-9759-4965-b1eb-ce54e304625d;DE;2028-03-10;;School;Regional;DE Zusätzlicher Ferientag,EN Additional holiday;MV-BBS
 aa17fa73-99a7-4123-a674-99a5153f575c;DE;2028-04-12;2028-04-21;School;Regional;DE Osterferien,EN Easter Holidays;MV-ABS,MV-BBS
-2c033497-106f-4600-ba34-0b0aedbec7f3;DE;2028-04-12;2028-04-21;School;Regional;DE Osterferien,EN Easter Holidays;MV-BBS
 6e2a0909-650d-43fe-869d-e2cbaa2bf9e3;DE;2028-05-26;;School;Regional;DE Zusätzlicher Ferientag,EN Additional holiday;MV-ABS,MV-BBS
 a2024625-80c4-4e1f-b54b-d2f3823786d2;DE;2028-06-02;2028-06-06;School;Regional;DE Pfingstferien,EN Pentecost Holidays;MV-ABS
 a3edc618-ff88-432e-b83b-3950ca02cdd7;DE;2028-06-26;2028-08-05;School;Regional;DE Sommerferien,EN Summer Holidays;MV-ABS


### PR DESCRIPTION
de-mv had a duplicated entry for Easter holidays in the mv-bbs group, I removed the line in question. The Holiday is provided by the line above, giving it to both groups mv-abs and mv-bbs.