### PR TITLE
fix(LV): correct Latvian holiday names from accusative to nominative case

### DIFF
--- a/src/lv/holidays/holidays.public.csv
+++ b/src/lv/holidays/holidays.public.csv
@@ -1,167 +1,167 @@
-﻿Id;Country;StartDate;EndDate;Type;RegionalScope;Tags;Name
-36224fd3-4638-4120-8915-7cfbf261f156;LV;2020-01-01;;Public;National;;LV Jaungada dienu,DE Neujahr,EN New Year's Day
-bfe4e5f5-056e-4455-910f-ea4cad3ce0c8;LV;2020-04-10;;Public;National;;LV Lielo Piektdienu,DE Karfreitag,EN Good Friday
+Id;Country;StartDate;EndDate;Type;RegionalScope;Tags;Name
+36224fd3-4638-4120-8915-7cfbf261f156;LV;2020-01-01;;Public;National;;LV Jaungada diena,DE Neujahr,EN New Year's Day
+bfe4e5f5-056e-4455-910f-ea4cad3ce0c8;LV;2020-04-10;;Public;National;;LV Lielā Piektdiena,DE Karfreitag,EN Good Friday
 3183bd6c-da60-467e-85f4-b205a668ff4a;LV;2020-04-12;;Public;National;;LV Pirmās Lieldienas,DE Ostersonntag,EN Easter Sunday
-c13219a4-f907-475d-a0cc-65cdb586e8ad;LV;2020-04-13;;Public;National;;LV Lieldienu dienu,DE Ostermontag,EN Easter Monday
-95d9b57c-f329-4e55-aa0c-9b3eef831aad;LV;2020-05-01;;Public;National;;LV Darba svētkus,DE Tag der Arbeit,EN Labour Day
-1dd21445-48c7-4ca9-81e3-f5d030d9fa81;LV;2020-05-04;;Public;National;;LV Latvijas Republikas Neatkarības atjaunošanas dienu,DE Tag der Wiederherstellung der Unabhängigkeit,EN Day of the Restoration of Independence
-5378a200-1e9f-46b6-a77e-c1b6e4182e6e;LV;2020-05-10;;Public;National;;LV Mātes dienu,DE Muttertag,EN Mother's Day
-dea7f587-be7c-451c-bd5d-a2e37e26b945;LV;2020-05-31;;Public;National;;LV Vasarsvētkus,DE Pfingsten,EN Pentecost
-75ba38d3-3bd2-4742-8611-1ccac9256b24;LV;2020-06-23;;Public;National;;LV Līgo dienu,DE Mittsommernacht,EN Midsummer's Eve
-a82b3c74-d6f1-48d0-a109-548483aa990a;LV;2020-06-24;;Public;National;;LV Jāņu dienu,DE Mittsommertag,EN Midsummer Day
-506ae5bf-bea7-4a2e-8faf-749e0323a92b;LV;2020-11-18;;Public;National;;LV Latvijas Republikas Proklamēšanas dienu,DE Tag der Ausrufung der Republik Lettland,EN Day of the Proclamation of the Republic of Latvia
+c13219a4-f907-475d-a0cc-65cdb586e8ad;LV;2020-04-13;;Public;National;;LV Otrās Lieldienas,DE Ostermontag,EN Easter Monday
+95d9b57c-f329-4e55-aa0c-9b3eef831aad;LV;2020-05-01;;Public;National;;LV Darba svētki,DE Tag der Arbeit,EN Labour Day
+1dd21445-48c7-4ca9-81e3-f5d030d9fa81;LV;2020-05-04;;Public;National;;LV Latvijas Republikas Neatkarības atjaunošanas diena,DE Tag der Wiederherstellung der Unabhängigkeit,EN Day of the Restoration of Independence
+5378a200-1e9f-46b6-a77e-c1b6e4182e6e;LV;2020-05-10;;Public;National;;LV Mātes diena,DE Muttertag,EN Mother's Day
+dea7f587-be7c-451c-bd5d-a2e37e26b945;LV;2020-05-31;;Public;National;;LV Vasarsvētki,DE Pfingsten,EN Pentecost
+75ba38d3-3bd2-4742-8611-1ccac9256b24;LV;2020-06-23;;Public;National;;LV Līgo diena,DE Mittsommernacht,EN Midsummer's Eve
+a82b3c74-d6f1-48d0-a109-548483aa990a;LV;2020-06-24;;Public;National;;LV Jāņu diena,DE Mittsommertag,EN Midsummer Day
+506ae5bf-bea7-4a2e-8faf-749e0323a92b;LV;2020-11-18;;Public;National;;LV Latvijas Republikas Proklamēšanas diena,DE Tag der Ausrufung der Republik Lettland,EN Day of the Proclamation of the Republic of Latvia
 a2cea80f-20cf-4534-acf5-dbe5a8a3596a;LV;2020-12-24;;Public;National;;LV Ziemassvētku vakars,DE Heiligabend,EN Christmas Eve
-db90f142-45f2-4683-a763-bf0ac5409795;LV;2020-12-25;;Public;National;;LV Ziemassvētki,DE Weihnachten,EN Christmas Day
+db90f142-45f2-4683-a763-bf0ac5409795;LV;2020-12-25;;Public;National;;LV Pirmie Ziemassvētki,DE Weihnachten,EN Christmas Day
 b5953872-f986-4278-94dd-8fb562b60b6b;LV;2020-12-26;;Public;National;;LV Otrie Ziemassvētki,DE 2. Weihnachtsfeiertag,EN 2nd Day of Christmas
-3eebb590-f287-473e-8f06-1e73a40c27d3;LV;2020-12-31;;Public;National;;LV Vecgada dienu,DE Silvester,EN New Year's Eve
-b884ac34-9ea0-47e0-8db6-14b639a17135;LV;2021-01-01;;Public;National;;LV Jaungada dienu,DE Neujahr,EN New Year's Day
-a1613743-688a-46d6-ab4f-54fe6f03c449;LV;2021-04-10;;Public;National;;LV Lielo Piektdienu,DE Karfreitag,EN Good Friday
+3eebb590-f287-473e-8f06-1e73a40c27d3;LV;2020-12-31;;Public;National;;LV Vecgada diena,DE Silvester,EN New Year's Eve
+b884ac34-9ea0-47e0-8db6-14b639a17135;LV;2021-01-01;;Public;National;;LV Jaungada diena,DE Neujahr,EN New Year's Day
+a1613743-688a-46d6-ab4f-54fe6f03c449;LV;2021-04-10;;Public;National;;LV Lielā Piektdiena,DE Karfreitag,EN Good Friday
 d9dae605-f35a-4851-9a91-cfe934140d9d;LV;2021-04-12;;Public;National;;LV Pirmās Lieldienas,DE Ostersonntag,EN Easter Sunday
-0ce8d7fc-6dce-4b3e-a2fa-d21d0ba7cbbe;LV;2021-04-13;;Public;National;;LV Lieldienu dienu,DE Ostermontag,EN Easter Monday
-af847dce-fdf6-4806-85c3-92a5d365a0d0;LV;2021-05-01;;Public;National;;LV Darba svētkus,DE Tag der Arbeit,EN Labour Day
-79ce4916-57b9-4e89-ab52-3030a56ac915;LV;2021-05-04;;Public;National;;LV Latvijas Republikas Neatkarības atjaunošanas dienu,DE Tag der Wiederherstellung der Unabhängigkeit,EN Day of the Restoration of Independence
-44756828-012c-4837-ae5a-92e98b31af53;LV;2021-05-10;;Public;National;;LV Mātes dienu,DE Muttertag,EN Mother's Day
-818710fe-ac1e-43bd-bb76-4a1cfb56057b;LV;2021-05-23;;Public;National;;LV Vasarsvētkus,DE Pfingsten,EN Pentecost
-42493605-2838-4960-a29c-7f2113c5a7c7;LV;2021-06-23;;Public;National;;LV Līgo dienu,DE Mittsommernacht,EN Midsummer's Eve
-cf779ad2-76be-49cc-aaf3-702c66bdb50a;LV;2021-06-24;;Public;National;;LV Jāņu dienu,DE Mittsommertag,EN Midsummer Day
-9b439458-15b6-4d41-9e3c-895b6209aff3;LV;2021-11-18;;Public;National;;LV Latvijas Republikas Proklamēšanas dienu,DE Tag der Ausrufung der Republik Lettland,EN Day of the Proclamation of the Republic of Latvia
+0ce8d7fc-6dce-4b3e-a2fa-d21d0ba7cbbe;LV;2021-04-13;;Public;National;;LV Otrās Lieldienas,DE Ostermontag,EN Easter Monday
+af847dce-fdf6-4806-85c3-92a5d365a0d0;LV;2021-05-01;;Public;National;;LV Darba svētki,DE Tag der Arbeit,EN Labour Day
+79ce4916-57b9-4e89-ab52-3030a56ac915;LV;2021-05-04;;Public;National;;LV Latvijas Republikas Neatkarības atjaunošanas diena,DE Tag der Wiederherstellung der Unabhängigkeit,EN Day of the Restoration of Independence
+44756828-012c-4837-ae5a-92e98b31af53;LV;2021-05-10;;Public;National;;LV Mātes diena,DE Muttertag,EN Mother's Day
+818710fe-ac1e-43bd-bb76-4a1cfb56057b;LV;2021-05-23;;Public;National;;LV Vasarsvētki,DE Pfingsten,EN Pentecost
+42493605-2838-4960-a29c-7f2113c5a7c7;LV;2021-06-23;;Public;National;;LV Līgo diena,DE Mittsommernacht,EN Midsummer's Eve
+cf779ad2-76be-49cc-aaf3-702c66bdb50a;LV;2021-06-24;;Public;National;;LV Jāņu diena,DE Mittsommertag,EN Midsummer Day
+9b439458-15b6-4d41-9e3c-895b6209aff3;LV;2021-11-18;;Public;National;;LV Latvijas Republikas Proklamēšanas diena,DE Tag der Ausrufung der Republik Lettland,EN Day of the Proclamation of the Republic of Latvia
 3d9cc3a0-1233-4751-8306-2414f0da2b8f;LV;2021-12-24;;Public;National;;LV Ziemassvētku vakars,DE Heiligabend,EN Christmas Eve
-6c81d3e8-e28b-453e-a719-bdb81da612f6;LV;2021-12-25;;Public;National;;LV Ziemassvētki,DE Weihnachten,EN Christmas Day
+6c81d3e8-e28b-453e-a719-bdb81da612f6;LV;2021-12-25;;Public;National;;LV Pirmie Ziemassvētki,DE Weihnachten,EN Christmas Day
 8e9fc179-1c0a-4ad9-8059-84fbc90bb084;LV;2021-12-26;;Public;National;;LV Otrie Ziemassvētki,DE 2. Weihnachtsfeiertag,EN 2nd Day of Christmas
-d91eb53b-5d45-4a97-8541-536c2a8bb2cb;LV;2021-12-31;;Public;National;;LV Vecgada dienu,DE Silvester,EN New Year's Eve
-91c1ad51-6a18-4ac5-81ab-454375027945;LV;2022-01-01;;Public;National;;LV Jaungada dienu,DE Neujahr,EN New Year's Day
-2cc93562-5ed6-4143-9ef0-be7aba2aab12;LV;2022-04-15;;Public;National;;LV Lielo Piektdienu,DE Karfreitag,EN Good Friday
+d91eb53b-5d45-4a97-8541-536c2a8bb2cb;LV;2021-12-31;;Public;National;;LV Vecgada diena,DE Silvester,EN New Year's Eve
+91c1ad51-6a18-4ac5-81ab-454375027945;LV;2022-01-01;;Public;National;;LV Jaungada diena,DE Neujahr,EN New Year's Day
+2cc93562-5ed6-4143-9ef0-be7aba2aab12;LV;2022-04-15;;Public;National;;LV Lielā Piektdiena,DE Karfreitag,EN Good Friday
 874a6267-e381-420c-9004-e13dc9486c4e;LV;2022-04-17;;Public;National;;LV Pirmās Lieldienas,DE Ostersonntag,EN Easter Sunday
-3dcb6cb8-eb16-4739-90c7-84ebc0d49d48;LV;2022-04-18;;Public;National;;LV Lieldienu dienu,DE Ostermontag,EN Easter Monday
-6ed39569-39e7-4833-acec-fb1cac24ba1a;LV;2022-05-01;;Public;National;;LV Darba svētkus,DE Tag der Arbeit,EN Labour Day
-bd007ee0-36f9-4a59-b8b9-43860e9b63aa;LV;2022-05-04;;Public;National;;LV Latvijas Republikas Neatkarības atjaunošanas dienu,DE Tag der Wiederherstellung der Unabhängigkeit,EN Day of the Restoration of Independence
-0f596d06-5919-4f4d-b351-32705790e9f8;LV;2022-05-08;;Public;National;;LV Mātes dienu,DE Muttertag,EN Mother's Day
-f1787dfd-de94-46b6-b9b1-a6def2921822;LV;2022-06-05;;Public;National;;LV Vasarsvētkus,DE Pfingsten,EN Pentecost
-af56291e-57b4-4b8e-be4e-dd16725cc87c;LV;2022-06-23;;Public;National;;LV Līgo dienu,DE Mittsommernacht,EN Midsummer's Eve
-e1839fad-95f3-42e1-9d62-46538f42cc01;LV;2022-06-24;;Public;National;;LV Jāņu dienu,DE Mittsommertag,EN Midsummer Day
-b2ef45bc-e1e2-4ea3-bebd-d79a2ec59d1a;LV;2022-11-18;;Public;National;;LV Latvijas Republikas Proklamēšanas dienu,DE Tag der Ausrufung der Republik Lettland,EN Day of the Proclamation of the Republic of Latvia
+3dcb6cb8-eb16-4739-90c7-84ebc0d49d48;LV;2022-04-18;;Public;National;;LV Otrās Lieldienas,DE Ostermontag,EN Easter Monday
+6ed39569-39e7-4833-acec-fb1cac24ba1a;LV;2022-05-01;;Public;National;;LV Darba svētki,DE Tag der Arbeit,EN Labour Day
+bd007ee0-36f9-4a59-b8b9-43860e9b63aa;LV;2022-05-04;;Public;National;;LV Latvijas Republikas Neatkarības atjaunošanas diena,DE Tag der Wiederherstellung der Unabhängigkeit,EN Day of the Restoration of Independence
+0f596d06-5919-4f4d-b351-32705790e9f8;LV;2022-05-08;;Public;National;;LV Mātes diena,DE Muttertag,EN Mother's Day
+f1787dfd-de94-46b6-b9b1-a6def2921822;LV;2022-06-05;;Public;National;;LV Vasarsvētki,DE Pfingsten,EN Pentecost
+af56291e-57b4-4b8e-be4e-dd16725cc87c;LV;2022-06-23;;Public;National;;LV Līgo diena,DE Mittsommernacht,EN Midsummer's Eve
+e1839fad-95f3-42e1-9d62-46538f42cc01;LV;2022-06-24;;Public;National;;LV Jāņu diena,DE Mittsommertag,EN Midsummer Day
+b2ef45bc-e1e2-4ea3-bebd-d79a2ec59d1a;LV;2022-11-18;;Public;National;;LV Latvijas Republikas Proklamēšanas diena,DE Tag der Ausrufung der Republik Lettland,EN Day of the Proclamation of the Republic of Latvia
 03b5d34c-2028-4440-aa96-0fa3a43ec471;LV;2022-12-24;;Public;National;;LV Ziemassvētku vakars,DE Heiligabend,EN Christmas Eve
-a96a1074-2974-4aae-a170-1b80b6eda042;LV;2022-12-25;;Public;National;;LV Ziemassvētki,DE Weihnachten,EN Christmas Day
+a96a1074-2974-4aae-a170-1b80b6eda042;LV;2022-12-25;;Public;National;;LV Pirmie Ziemassvētki,DE Weihnachten,EN Christmas Day
 7fd5e878-086c-4836-8b60-b4ce31eb6861;LV;2022-12-26;;Public;National;;LV Otrie Ziemassvētki,DE 2. Weihnachtsfeiertag,EN 2nd Day of Christmas
-04e2a18c-c73d-414f-b0df-c70736fa0903;LV;2022-12-31;;Public;National;;LV Vecgada dienu,DE Silvester,EN New Year's Eve
-48b49b8a-fda3-4c27-8275-4179ccaf7d86;LV;2023-01-01;;Public;National;;LV Jaungada dienu,DE Neujahr,EN New Year's Day
-7d4182ba-2550-4119-b25a-ff726c10616a;LV;2023-04-07;;Public;National;;LV Lielo Piektdienu,DE Karfreitag,EN Good Friday
+04e2a18c-c73d-414f-b0df-c70736fa0903;LV;2022-12-31;;Public;National;;LV Vecgada diena,DE Silvester,EN New Year's Eve
+48b49b8a-fda3-4c27-8275-4179ccaf7d86;LV;2023-01-01;;Public;National;;LV Jaungada diena,DE Neujahr,EN New Year's Day
+7d4182ba-2550-4119-b25a-ff726c10616a;LV;2023-04-07;;Public;National;;LV Lielā Piektdiena,DE Karfreitag,EN Good Friday
 53b8dcdb-6ccb-4aa8-8a44-751386b1a0f6;LV;2023-04-09;;Public;National;;LV Pirmās Lieldienas,DE Ostersonntag,EN Easter Sunday
-5b2cb7bf-4103-4cbf-926d-28555760276d;LV;2023-04-10;;Public;National;;LV Lieldienu dienu,DE Ostermontag,EN Easter Monday
-fd9dcdd2-c2f2-46e4-9e46-633b79e79072;LV;2023-05-01;;Public;National;;LV Darba svētkus,DE Tag der Arbeit,EN Labour Day
-eb0916a6-7fe1-4d88-ae06-60d375108852;LV;2023-05-04;;Public;National;;LV Latvijas Republikas Neatkarības atjaunošanas dienu,DE Tag der Wiederherstellung der Unabhängigkeit,EN Day of the Restoration of Independence
-48f2e1c4-e32a-4c6c-ba3d-85b3d2cddf66;LV;2023-05-14;;Public;National;;LV Mātes dienu,DE Muttertag,EN Mother's Day
-a1abd2a2-7cf6-4e5d-8240-df5eec265e57;LV;2023-05-28;;Public;National;;LV Vasarsvētkus,DE Pfingsten,EN Pentecost
-d3e9c4fb-db29-4ef6-ad03-834e852aea59;LV;2023-05-29;;Public;National;OneTime;LV Izcīnot bronzas medaļu 2023. gada pasaules čempionātā hokejā,DE Gewinn der Bronzemedaille bei der Eishockey-Weltmeisterschaft 2023,EN Winning the bronze medal at the 2023 Ice Hockey World Championship
-536e0884-cb19-4f40-956e-84537f44c5ba;LV;2023-06-23;;Public;National;;LV Līgo dienu,DE Mittsommernacht,EN Midsummer's Eve
-2fc00b26-c110-44fd-8852-75a44e1583b3;LV;2023-06-24;;Public;National;;LV Jāņu dienu,DE Mittsommertag,EN Midsummer Day
-d3142641-b531-45e6-9898-64604f5b69d8;LV;2023-11-18;;Public;National;;LV Latvijas Republikas Proklamēšanas dienu,DE Tag der Ausrufung der Republik Lettland,EN Day of the Proclamation of the Republic of Latvia
+5b2cb7bf-4103-4cbf-926d-28555760276d;LV;2023-04-10;;Public;National;;LV Otrās Lieldienas,DE Ostermontag,EN Easter Monday
+fd9dcdd2-c2f2-46e4-9e46-633b79e79072;LV;2023-05-01;;Public;National;;LV Darba svētki,DE Tag der Arbeit,EN Labour Day
+eb0916a6-7fe1-4d88-ae06-60d375108852;LV;2023-05-04;;Public;National;;LV Latvijas Republikas Neatkarības atjaunošanas diena,DE Tag der Wiederherstellung der Unabhängigkeit,EN Day of the Restoration of Independence
+48f2e1c4-e32a-4c6c-ba3d-85b3d2cddf66;LV;2023-05-14;;Public;National;;LV Mātes diena,DE Muttertag,EN Mother's Day
+a1abd2a2-7cf6-4e5d-8240-df5eec265e57;LV;2023-05-28;;Public;National;;LV Vasarsvētki,DE Pfingsten,EN Pentecost
+d3e9c4fb-db29-4ef6-ad03-834e852aea59;LV;2023-05-29;;Public;National;OneTime;LV Bronzas medaļa 2023. gada Pasaules hokeja čempionātā,DE Gewinn der Bronzemedaille bei der Eishockey-Weltmeisterschaft 2023,EN Winning the bronze medal at the 2023 Ice Hockey World Championship
+536e0884-cb19-4f40-956e-84537f44c5ba;LV;2023-06-23;;Public;National;;LV Līgo diena,DE Mittsommernacht,EN Midsummer's Eve
+2fc00b26-c110-44fd-8852-75a44e1583b3;LV;2023-06-24;;Public;National;;LV Jāņu diena,DE Mittsommertag,EN Midsummer Day
+d3142641-b531-45e6-9898-64604f5b69d8;LV;2023-11-18;;Public;National;;LV Latvijas Republikas Proklamēšanas diena,DE Tag der Ausrufung der Republik Lettland,EN Day of the Proclamation of the Republic of Latvia
 63a982d5-d49d-4d0b-8e3a-4bba5ffb7c2d;LV;2023-12-24;;Public;National;;LV Ziemassvētku vakars,DE Heiligabend,EN Christmas Eve
-c9c1cb73-1ff7-4b7d-8cfa-3ddab1728814;LV;2023-12-25;;Public;National;;LV Ziemassvētki,DE Weihnachten,EN Christmas Day
+c9c1cb73-1ff7-4b7d-8cfa-3ddab1728814;LV;2023-12-25;;Public;National;;LV Pirmie Ziemassvētki,DE Weihnachten,EN Christmas Day
 6430f091-e85c-4cbb-b39a-49e6ee47d442;LV;2023-12-26;;Public;National;;LV Otrie Ziemassvētki,DE 2. Weihnachtsfeiertag,EN 2nd Day of Christmas
-95d8143a-e359-4034-afbd-699477a4517c;LV;2023-12-31;;Public;National;;LV Vecgada dienu,DE Silvester,EN New Year's Eve
-bcd34ed8-6f13-4c25-af2f-d9b42435994b;LV;2024-01-01;;Public;National;;LV Jaungada dienu,DE Neujahr,EN New Year's Day
-00ffa0c8-6aea-422a-8737-79427e47fbbe;LV;2024-03-29;;Public;National;;LV Lielo Piektdienu,DE Karfreitag,EN Good Friday
+95d8143a-e359-4034-afbd-699477a4517c;LV;2023-12-31;;Public;National;;LV Vecgada diena,DE Silvester,EN New Year's Eve
+bcd34ed8-6f13-4c25-af2f-d9b42435994b;LV;2024-01-01;;Public;National;;LV Jaungada diena,DE Neujahr,EN New Year's Day
+00ffa0c8-6aea-422a-8737-79427e47fbbe;LV;2024-03-29;;Public;National;;LV Lielā Piektdiena,DE Karfreitag,EN Good Friday
 53f04480-328e-4ca6-b5b8-e34a70b68f20;LV;2024-03-31;;Public;National;;LV Pirmās Lieldienas,DE Ostersonntag,EN Easter Sunday
-64fd7695-cfb9-4a5b-bdaa-07c1dc654e6a;LV;2024-04-01;;Public;National;;LV Lieldienu dienu,DE Ostermontag,EN Easter Monday
-d763a752-d5d6-416c-946e-c4a180a0c421;LV;2024-05-01;;Public;National;;LV Darba svētkus,DE Tag der Arbeit,EN Labour Day
-bd244319-8274-47d8-8ce0-bad6f2cb2f1f;LV;2024-05-04;;Public;National;;LV Latvijas Republikas Neatkarības atjaunošanas dienu,DE Tag der Wiederherstellung der Unabhängigkeit,EN Day of the Restoration of Independence
-49fe5b4f-dfad-4f5e-b658-aafc390bba50;LV;2024-05-12;;Public;National;;LV Mātes dienu,DE Muttertag,EN Mother's Day
-9d514773-6cdb-45de-a7a0-b0d232c3e455;LV;2024-05-19;;Public;National;;LV Vasarsvētkus,DE Pfingsten,EN Pentecost
-a74b94bc-71f7-474c-84f8-4d3c61ba18d7;LV;2024-06-23;;Public;National;;LV Līgo dienu,DE Mittsommernacht,EN Midsummer's Eve
-820d55a5-7e47-47f6-bb24-75b3be6e59e8;LV;2024-06-24;;Public;National;;LV Jāņu dienu,DE Mittsommertag,EN Midsummer Day
-f0f2a565-d4b3-46e1-bb11-70724aab6c2f;LV;2024-11-18;;Public;National;;LV Latvijas Republikas Proklamēšanas dienu,DE Tag der Ausrufung der Republik Lettland,EN Day of the Proclamation of the Republic of Latvia
+64fd7695-cfb9-4a5b-bdaa-07c1dc654e6a;LV;2024-04-01;;Public;National;;LV Otrās Lieldienas,DE Ostermontag,EN Easter Monday
+d763a752-d5d6-416c-946e-c4a180a0c421;LV;2024-05-01;;Public;National;;LV Darba svētki,DE Tag der Arbeit,EN Labour Day
+bd244319-8274-47d8-8ce0-bad6f2cb2f1f;LV;2024-05-04;;Public;National;;LV Latvijas Republikas Neatkarības atjaunošanas diena,DE Tag der Wiederherstellung der Unabhängigkeit,EN Day of the Restoration of Independence
+49fe5b4f-dfad-4f5e-b658-aafc390bba50;LV;2024-05-12;;Public;National;;LV Mātes diena,DE Muttertag,EN Mother's Day
+9d514773-6cdb-45de-a7a0-b0d232c3e455;LV;2024-05-19;;Public;National;;LV Vasarsvētki,DE Pfingsten,EN Pentecost
+a74b94bc-71f7-474c-84f8-4d3c61ba18d7;LV;2024-06-23;;Public;National;;LV Līgo diena,DE Mittsommernacht,EN Midsummer's Eve
+820d55a5-7e47-47f6-bb24-75b3be6e59e8;LV;2024-06-24;;Public;National;;LV Jāņu diena,DE Mittsommertag,EN Midsummer Day
+f0f2a565-d4b3-46e1-bb11-70724aab6c2f;LV;2024-11-18;;Public;National;;LV Latvijas Republikas Proklamēšanas diena,DE Tag der Ausrufung der Republik Lettland,EN Day of the Proclamation of the Republic of Latvia
 0c08957b-c38b-4484-81d9-0615e18e7da9;LV;2024-12-24;;Public;National;;LV Ziemassvētku vakars,DE Heiligabend,EN Christmas Eve
-35631cbb-ec8d-4933-97bf-eab64dd0ced2;LV;2024-12-25;;Public;National;;LV Ziemassvētki,DE Weihnachten,EN Christmas Day
+35631cbb-ec8d-4933-97bf-eab64dd0ced2;LV;2024-12-25;;Public;National;;LV Pirmie Ziemassvētki,DE Weihnachten,EN Christmas Day
 eb712222-47b6-4318-a7b8-6357261bf04a;LV;2024-12-26;;Public;National;;LV Otrie Ziemassvētki,DE 2. Weihnachtsfeiertag,EN 2nd Day of Christmas
-f5688db4-c004-4375-882d-707317f3e4e6;LV;2024-12-31;;Public;National;;LV Vecgada dienu,DE Silvester,EN New Year's Eve
-fbd2044d-de12-42f9-862e-4b0da04fca76;LV;2025-01-01;;Public;National;;LV Jaungada dienu,DE Neujahr,EN New Year's Day
-c24a44d2-4b84-400e-8fa6-30311e21ed17;LV;2025-04-18;;Public;National;;LV Lielo Piektdienu,DE Karfreitag,EN Good Friday
+f5688db4-c004-4375-882d-707317f3e4e6;LV;2024-12-31;;Public;National;;LV Vecgada diena,DE Silvester,EN New Year's Eve
+fbd2044d-de12-42f9-862e-4b0da04fca76;LV;2025-01-01;;Public;National;;LV Jaungada diena,DE Neujahr,EN New Year's Day
+c24a44d2-4b84-400e-8fa6-30311e21ed17;LV;2025-04-18;;Public;National;;LV Lielā Piektdiena,DE Karfreitag,EN Good Friday
 9b970117-fb3d-4deb-9e08-8cd07446c1dd;LV;2025-04-20;;Public;National;;LV Pirmās Lieldienas,DE Ostersonntag,EN Easter Sunday
-e76cb119-86a8-4535-aa91-3aed488dbf84;LV;2025-04-21;;Public;National;;LV Lieldienu dienu,DE Ostermontag,EN Easter Monday
-b7fba55c-ee77-4a56-92c7-42e4260bddc3;LV;2025-05-01;;Public;National;;LV Darba svētkus,DE Tag der Arbeit,EN Labour Day
-48309ae2-d850-473a-af8d-4f15a7bc3020;LV;2025-05-04;;Public;National;;LV Latvijas Republikas Neatkarības atjaunošanas dienu,DE Tag der Wiederherstellung der Unabhängigkeit,EN Day of the Restoration of Independence
-1307175c-fcf8-46d4-9302-8b5cba8b0994;LV;2025-05-11;;Public;National;;LV Mātes dienu,DE Muttertag,EN Mother's Day
-f8dcc8a0-53e7-42c5-bb7d-1055d0f21058;LV;2025-06-08;;Public;National;;LV Vasarsvētkus,DE Pfingsten,EN Pentecost
-fed50895-e80f-4252-ba04-d1a9ca97fcf2;LV;2025-06-23;;Public;National;;LV Līgo dienu,DE Mittsommernacht,EN Midsummer's Eve
-ded4681f-00dd-47a5-bb08-8cf3e8a8a221;LV;2025-06-24;;Public;National;;LV Jāņu dienu,DE Mittsommertag,EN Midsummer Day
-7ae2c6f3-d51d-485f-8ab5-06a6c7d6639d;LV;2025-11-18;;Public;National;;LV Latvijas Republikas Proklamēšanas dienu,DE Tag der Ausrufung der Republik Lettland,EN Day of the Proclamation of the Republic of Latvia
+e76cb119-86a8-4535-aa91-3aed488dbf84;LV;2025-04-21;;Public;National;;LV Otrās Lieldienas,DE Ostermontag,EN Easter Monday
+b7fba55c-ee77-4a56-92c7-42e4260bddc3;LV;2025-05-01;;Public;National;;LV Darba svētki,DE Tag der Arbeit,EN Labour Day
+48309ae2-d850-473a-af8d-4f15a7bc3020;LV;2025-05-04;;Public;National;;LV Latvijas Republikas Neatkarības atjaunošanas diena,DE Tag der Wiederherstellung der Unabhängigkeit,EN Day of the Restoration of Independence
+1307175c-fcf8-46d4-9302-8b5cba8b0994;LV;2025-05-11;;Public;National;;LV Mātes diena,DE Muttertag,EN Mother's Day
+f8dcc8a0-53e7-42c5-bb7d-1055d0f21058;LV;2025-06-08;;Public;National;;LV Vasarsvētki,DE Pfingsten,EN Pentecost
+fed50895-e80f-4252-ba04-d1a9ca97fcf2;LV;2025-06-23;;Public;National;;LV Līgo diena,DE Mittsommernacht,EN Midsummer's Eve
+ded4681f-00dd-47a5-bb08-8cf3e8a8a221;LV;2025-06-24;;Public;National;;LV Jāņu diena,DE Mittsommertag,EN Midsummer Day
+7ae2c6f3-d51d-485f-8ab5-06a6c7d6639d;LV;2025-11-18;;Public;National;;LV Latvijas Republikas Proklamēšanas diena,DE Tag der Ausrufung der Republik Lettland,EN Day of the Proclamation of the Republic of Latvia
 1a31b37a-4dcf-4433-a4d2-98eb4392c780;LV;2025-12-24;;Public;National;;LV Ziemassvētku vakars,DE Heiligabend,EN Christmas Eve
-8fe682a5-186c-47f5-82af-92866f4cd7e3;LV;2025-12-25;;Public;National;;LV Ziemassvētki,DE Weihnachten,EN Christmas Day
+8fe682a5-186c-47f5-82af-92866f4cd7e3;LV;2025-12-25;;Public;National;;LV Pirmie Ziemassvētki,DE Weihnachten,EN Christmas Day
 2596f707-1384-4ee1-9eeb-0725a2ee2147;LV;2025-12-26;;Public;National;;LV Otrie Ziemassvētki,DE 2. Weihnachtsfeiertag,EN 2nd Day of Christmas
-c2039489-70fa-466d-88f1-7704d3e1f439;LV;2025-12-31;;Public;National;;LV Vecgada dienu,DE Silvester,EN New Year's Eve
-64d88e82-ba80-4f97-a2f5-2be087aee204;LV;2026-01-01;;Public;National;;LV Jaungada dienu,DE Neujahr,EN New Year's Day
-8a5399f9-f7bf-455d-81ca-45fac89a9d08;LV;2026-04-03;;Public;National;;LV Lielo Piektdienu,DE Karfreitag,EN Good Friday
+c2039489-70fa-466d-88f1-7704d3e1f439;LV;2025-12-31;;Public;National;;LV Vecgada diena,DE Silvester,EN New Year's Eve
+64d88e82-ba80-4f97-a2f5-2be087aee204;LV;2026-01-01;;Public;National;;LV Jaungada diena,DE Neujahr,EN New Year's Day
+8a5399f9-f7bf-455d-81ca-45fac89a9d08;LV;2026-04-03;;Public;National;;LV Lielā Piektdiena,DE Karfreitag,EN Good Friday
 75e036a0-324a-4b32-a55f-b8de53b6f1a3;LV;2026-04-05;;Public;National;;LV Pirmās Lieldienas,DE Ostersonntag,EN Easter Sunday
-1706274d-0e2f-43bb-9069-3b5b6b17bded;LV;2026-04-06;;Public;National;;LV Lieldienu dienu,DE Ostermontag,EN Easter Monday
-16f2fbad-6047-44ab-9190-95d98cbc36fb;LV;2026-05-01;;Public;National;;LV Darba svētkus,DE Tag der Arbeit,EN Labour Day
-c4d4e812-6cb6-48a0-9070-073adee0a27d;LV;2026-05-04;;Public;National;;LV Latvijas Republikas Neatkarības atjaunošanas dienu,DE Tag der Wiederherstellung der Unabhängigkeit,EN Day of the Restoration of Independence
-3fe0a187-b16b-4e7b-abcf-c147d480f3d1;LV;2026-05-10;;Public;National;;LV Mātes dienu,DE Muttertag,EN Mother's Day
-ddfe2f91-439e-48bf-8d65-b357b0d86c51;LV;2026-05-24;;Public;National;;LV Vasarsvētkus,DE Pfingsten,EN Pentecost
-10065060-31cb-473c-9cbb-b0ef3d159427;LV;2026-06-23;;Public;National;;LV Līgo dienu,DE Mittsommernacht,EN Midsummer's Eve
-b8b9036b-085f-4ffe-a3ad-702ee036c957;LV;2026-06-24;;Public;National;;LV Jāņu dienu,DE Mittsommertag,EN Midsummer Day
-4e54e238-9d59-4efd-991d-65f56d0453c4;LV;2026-11-18;;Public;National;;LV Latvijas Republikas Proklamēšanas dienu,DE Tag der Ausrufung der Republik Lettland,EN Day of the Proclamation of the Republic of Latvia
+1706274d-0e2f-43bb-9069-3b5b6b17bded;LV;2026-04-06;;Public;National;;LV Otrās Lieldienas,DE Ostermontag,EN Easter Monday
+16f2fbad-6047-44ab-9190-95d98cbc36fb;LV;2026-05-01;;Public;National;;LV Darba svētki,DE Tag der Arbeit,EN Labour Day
+c4d4e812-6cb6-48a0-9070-073adee0a27d;LV;2026-05-04;;Public;National;;LV Latvijas Republikas Neatkarības atjaunošanas diena,DE Tag der Wiederherstellung der Unabhängigkeit,EN Day of the Restoration of Independence
+3fe0a187-b16b-4e7b-abcf-c147d480f3d1;LV;2026-05-10;;Public;National;;LV Mātes diena,DE Muttertag,EN Mother's Day
+ddfe2f91-439e-48bf-8d65-b357b0d86c51;LV;2026-05-24;;Public;National;;LV Vasarsvētki,DE Pfingsten,EN Pentecost
+10065060-31cb-473c-9cbb-b0ef3d159427;LV;2026-06-23;;Public;National;;LV Līgo diena,DE Mittsommernacht,EN Midsummer's Eve
+b8b9036b-085f-4ffe-a3ad-702ee036c957;LV;2026-06-24;;Public;National;;LV Jāņu diena,DE Mittsommertag,EN Midsummer Day
+4e54e238-9d59-4efd-991d-65f56d0453c4;LV;2026-11-18;;Public;National;;LV Latvijas Republikas Proklamēšanas diena,DE Tag der Ausrufung der Republik Lettland,EN Day of the Proclamation of the Republic of Latvia
 889bee78-cf36-4091-994c-b8fbce982a89;LV;2026-12-24;;Public;National;;LV Ziemassvētku vakars,DE Heiligabend,EN Christmas Eve
-f8e1a602-0d03-48f8-bb33-6d1ec393dd9d;LV;2026-12-25;;Public;National;;LV Ziemassvētki,DE Weihnachten,EN Christmas Day
+f8e1a602-0d03-48f8-bb33-6d1ec393dd9d;LV;2026-12-25;;Public;National;;LV Pirmie Ziemassvētki,DE Weihnachten,EN Christmas Day
 30e614f5-1afc-437f-a889-6909d001ad20;LV;2026-12-26;;Public;National;;LV Otrie Ziemassvētki,DE 2. Weihnachtsfeiertag,EN 2nd Day of Christmas
-aa30d829-4374-45da-ba28-353fba7a84f0;LV;2026-12-31;;Public;National;;LV Vecgada dienu,DE Silvester,EN New Year's Eve
-66b5aea2-cd45-4ffe-8e1d-e9b96a0f0f38;LV;2027-01-01;;Public;National;;LV Jaungada dienu,DE Neujahr,EN New Year's Day
-58488a72-0a4b-415c-8e8e-33902ae15c44;LV;2027-03-26;;Public;National;;LV Lielo Piektdienu,DE Karfreitag,EN Good Friday
+aa30d829-4374-45da-ba28-353fba7a84f0;LV;2026-12-31;;Public;National;;LV Vecgada diena,DE Silvester,EN New Year's Eve
+66b5aea2-cd45-4ffe-8e1d-e9b96a0f0f38;LV;2027-01-01;;Public;National;;LV Jaungada diena,DE Neujahr,EN New Year's Day
+58488a72-0a4b-415c-8e8e-33902ae15c44;LV;2027-03-26;;Public;National;;LV Lielā Piektdiena,DE Karfreitag,EN Good Friday
 92895b2e-f450-44db-8c7d-cf820f0680c6;LV;2027-03-28;;Public;National;;LV Pirmās Lieldienas,DE Ostersonntag,EN Easter Sunday
-de45b6d5-0590-4515-ac2b-b28952fde9af;LV;2027-03-29;;Public;National;;LV Lieldienu dienu,DE Ostermontag,EN Easter Monday
-b578047b-ee8d-43af-ad59-7139701d1a95;LV;2027-05-01;;Public;National;;LV Darba svētkus,DE Tag der Arbeit,EN Labour Day
-9fcca6e2-d4d2-4560-8902-0299922671bb;LV;2027-05-04;;Public;National;;LV Latvijas Republikas Neatkarības atjaunošanas dienu,DE Tag der Wiederherstellung der Unabhängigkeit,EN Day of the Restoration of Independence
-0d1e531a-41ce-442d-9773-e6e49dcdafb1;LV;2027-05-09;;Public;National;;LV Mātes dienu,DE Muttertag,EN Mother's Day
-049a6895-bcbc-42a0-8965-854b3c8f9b60;LV;2027-05-16;;Public;National;;LV Vasarsvētkus,DE Pfingsten,EN Pentecost
-24cd55e3-b214-4ab5-9a9b-a8d8f2344ad6;LV;2027-06-23;;Public;National;;LV Līgo dienu,DE Mittsommernacht,EN Midsummer's Eve
-e25cc8e5-dfde-469a-925c-e1056a54f69b;LV;2027-06-24;;Public;National;;LV Jāņu dienu,DE Mittsommertag,EN Midsummer Day
-0ad7305d-fc42-46f2-8bda-fa6f3d4a4079;LV;2027-11-18;;Public;National;;LV Latvijas Republikas Proklamēšanas dienu,DE Tag der Ausrufung der Republik Lettland,EN Day of the Proclamation of the Republic of Latvia
+de45b6d5-0590-4515-ac2b-b28952fde9af;LV;2027-03-29;;Public;National;;LV Otrās Lieldienas,DE Ostermontag,EN Easter Monday
+b578047b-ee8d-43af-ad59-7139701d1a95;LV;2027-05-01;;Public;National;;LV Darba svētki,DE Tag der Arbeit,EN Labour Day
+9fcca6e2-d4d2-4560-8902-0299922671bb;LV;2027-05-04;;Public;National;;LV Latvijas Republikas Neatkarības atjaunošanas diena,DE Tag der Wiederherstellung der Unabhängigkeit,EN Day of the Restoration of Independence
+0d1e531a-41ce-442d-9773-e6e49dcdafb1;LV;2027-05-09;;Public;National;;LV Mātes diena,DE Muttertag,EN Mother's Day
+049a6895-bcbc-42a0-8965-854b3c8f9b60;LV;2027-05-16;;Public;National;;LV Vasarsvētki,DE Pfingsten,EN Pentecost
+24cd55e3-b214-4ab5-9a9b-a8d8f2344ad6;LV;2027-06-23;;Public;National;;LV Līgo diena,DE Mittsommernacht,EN Midsummer's Eve
+e25cc8e5-dfde-469a-925c-e1056a54f69b;LV;2027-06-24;;Public;National;;LV Jāņu diena,DE Mittsommertag,EN Midsummer Day
+0ad7305d-fc42-46f2-8bda-fa6f3d4a4079;LV;2027-11-18;;Public;National;;LV Latvijas Republikas Proklamēšanas diena,DE Tag der Ausrufung der Republik Lettland,EN Day of the Proclamation of the Republic of Latvia
 a54b3588-ece7-4487-9813-f2a71c78aa5f;LV;2027-12-24;;Public;National;;LV Ziemassvētku vakars,DE Heiligabend,EN Christmas Eve
-4053869c-5533-4c53-b241-358f98642f82;LV;2027-12-25;;Public;National;;LV Ziemassvētki,DE Weihnachten,EN Christmas Day
+4053869c-5533-4c53-b241-358f98642f82;LV;2027-12-25;;Public;National;;LV Pirmie Ziemassvētki,DE Weihnachten,EN Christmas Day
 0c4c9b01-ea66-4054-999a-5460873466e7;LV;2027-12-26;;Public;National;;LV Otrie Ziemassvētki,DE 2. Weihnachtsfeiertag,EN 2nd Day of Christmas
-4ca8de40-39b6-43e1-9730-c17ce60335af;LV;2027-12-31;;Public;National;;LV Vecgada dienu,DE Silvester,EN New Year's Eve
-fd1e4dce-38e3-43bb-a320-3a27e23bb2c5;LV;2028-01-01;;Public;National;;LV Jaungada dienu,DE Neujahr,EN New Year's Day
-8f919e28-b6df-454a-b074-d101354d90e2;LV;2028-04-14;;Public;National;;LV Lielo Piektdienu,DE Karfreitag,EN Good Friday
+4ca8de40-39b6-43e1-9730-c17ce60335af;LV;2027-12-31;;Public;National;;LV Vecgada diena,DE Silvester,EN New Year's Eve
+fd1e4dce-38e3-43bb-a320-3a27e23bb2c5;LV;2028-01-01;;Public;National;;LV Jaungada diena,DE Neujahr,EN New Year's Day
+8f919e28-b6df-454a-b074-d101354d90e2;LV;2028-04-14;;Public;National;;LV Lielā Piektdiena,DE Karfreitag,EN Good Friday
 1ce8e25b-77aa-4800-b1c9-54f95225025d;LV;2028-04-16;;Public;National;;LV Pirmās Lieldienas,DE Ostersonntag,EN Easter Sunday
-e3c3fbe6-4528-4bdf-85c6-17493ff56cb6;LV;2028-04-17;;Public;National;;LV Lieldienu dienu,DE Ostermontag,EN Easter Monday
-b0b45d3f-7d37-4758-ac99-90b160956818;LV;2028-05-01;;Public;National;;LV Darba svētkus,DE Tag der Arbeit,EN Labour Day
-a736cfc2-eb45-4fd7-ad85-00b99cd9ec21;LV;2028-05-04;;Public;National;;LV Latvijas Republikas Neatkarības atjaunošanas dienu,DE Tag der Wiederherstellung der Unabhängigkeit,EN Day of the Restoration of Independence
-541ceb6c-9881-468d-973d-f2e78d572878;LV;2028-05-14;;Public;National;;LV Mātes dienu,DE Muttertag,EN Mother's Day
-e5998de9-fc97-4e29-82d5-8f6cb2183106;LV;2028-06-04;;Public;National;;LV Vasarsvētkus,DE Pfingsten,EN Pentecost
-a5b277e8-0d9a-4216-bea4-9ff98b27e8e0;LV;2028-06-23;;Public;National;;LV Līgo dienu,DE Mittsommernacht,EN Midsummer's Eve
-754020fd-100a-4e4c-a5c8-1d2f03885829;LV;2028-06-24;;Public;National;;LV Jāņu dienu,DE Mittsommertag,EN Midsummer Day
-274fce7b-b9bd-4975-b0fe-1bc4df258754;LV;2028-11-18;;Public;National;;LV Latvijas Republikas Proklamēšanas dienu,DE Tag der Ausrufung der Republik Lettland,EN Day of the Proclamation of the Republic of Latvia
+e3c3fbe6-4528-4bdf-85c6-17493ff56cb6;LV;2028-04-17;;Public;National;;LV Otrās Lieldienas,DE Ostermontag,EN Easter Monday
+b0b45d3f-7d37-4758-ac99-90b160956818;LV;2028-05-01;;Public;National;;LV Darba svētki,DE Tag der Arbeit,EN Labour Day
+a736cfc2-eb45-4fd7-ad85-00b99cd9ec21;LV;2028-05-04;;Public;National;;LV Latvijas Republikas Neatkarības atjaunošanas diena,DE Tag der Wiederherstellung der Unabhängigkeit,EN Day of the Restoration of Independence
+541ceb6c-9881-468d-973d-f2e78d572878;LV;2028-05-14;;Public;National;;LV Mātes diena,DE Muttertag,EN Mother's Day
+e5998de9-fc97-4e29-82d5-8f6cb2183106;LV;2028-06-04;;Public;National;;LV Vasarsvētki,DE Pfingsten,EN Pentecost
+a5b277e8-0d9a-4216-bea4-9ff98b27e8e0;LV;2028-06-23;;Public;National;;LV Līgo diena,DE Mittsommernacht,EN Midsummer's Eve
+754020fd-100a-4e4c-a5c8-1d2f03885829;LV;2028-06-24;;Public;National;;LV Jāņu diena,DE Mittsommertag,EN Midsummer Day
+274fce7b-b9bd-4975-b0fe-1bc4df258754;LV;2028-11-18;;Public;National;;LV Latvijas Republikas Proklamēšanas diena,DE Tag der Ausrufung der Republik Lettland,EN Day of the Proclamation of the Republic of Latvia
 cd6f08db-cb60-4fe2-95e6-57b7833b55b7;LV;2028-12-24;;Public;National;;LV Ziemassvētku vakars,DE Heiligabend,EN Christmas Eve
-78d807ec-88c3-44d6-a4ea-41bfe0ed3b80;LV;2028-12-25;;Public;National;;LV Ziemassvētki,DE Weihnachten,EN Christmas Day
+78d807ec-88c3-44d6-a4ea-41bfe0ed3b80;LV;2028-12-25;;Public;National;;LV Pirmie Ziemassvētki,DE Weihnachten,EN Christmas Day
 ce9bbc06-3b4c-4daa-8d34-21f1026dc61e;LV;2028-12-26;;Public;National;;LV Otrie Ziemassvētki,DE 2. Weihnachtsfeiertag,EN 2nd Day of Christmas
-7781b08d-c57c-4698-be8d-2ff65eaef982;LV;2028-12-31;;Public;National;;LV Vecgada dienu,DE Silvester,EN New Year's Eve
-3b085ace-11e4-4535-a931-4d7408098895;LV;2029-01-01;;Public;National;;LV Jaungada dienu,DE Neujahr,EN New Year's Day
-3a02ac1f-6a4a-4051-8560-c7e8cfc8da8d;LV;2029-03-30;;Public;National;;LV Lielo Piektdienu,DE Karfreitag,EN Good Friday
+7781b08d-c57c-4698-be8d-2ff65eaef982;LV;2028-12-31;;Public;National;;LV Vecgada diena,DE Silvester,EN New Year's Eve
+3b085ace-11e4-4535-a931-4d7408098895;LV;2029-01-01;;Public;National;;LV Jaungada diena,DE Neujahr,EN New Year's Day
+3a02ac1f-6a4a-4051-8560-c7e8cfc8da8d;LV;2029-03-30;;Public;National;;LV Lielā Piektdiena,DE Karfreitag,EN Good Friday
 e8492c07-331e-4f41-aedf-6dbf372bcadd;LV;2029-04-01;;Public;National;;LV Pirmās Lieldienas,DE Ostersonntag,EN Easter Sunday
-3ca8cc69-c9eb-4c55-8b1a-9f713d145d94;LV;2029-04-02;;Public;National;;LV Lieldienu dienu,DE Ostermontag,EN Easter Monday
-69eba023-1e14-421f-a6e0-7c76e0dcf466;LV;2029-05-01;;Public;National;;LV Darba svētkus,DE Tag der Arbeit,EN Labour Day
-9983f97e-e50e-4667-8805-08d81ef19701;LV;2029-05-04;;Public;National;;LV Latvijas Republikas Neatkarības atjaunošanas dienu,DE Tag der Wiederherstellung der Unabhängigkeit,EN Day of the Restoration of Independence
-c7c0eeee-3d05-4efd-a8dd-14e2d9e441ff;LV;2029-05-13;;Public;National;;LV Mātes dienu,DE Muttertag,EN Mother's Day
-aec65883-0e19-4b62-a292-9f0787fb1e69;LV;2029-05-20;;Public;National;;LV Vasarsvētkus,DE Pfingsten,EN Pentecost
-c6fc6146-34c0-4539-825d-7844d3ebe54f;LV;2029-06-23;;Public;National;;LV Līgo dienu,DE Mittsommernacht,EN Midsummer's Eve
-15ff7d0b-3e24-4ab5-91c7-0f2661fcc512;LV;2029-06-24;;Public;National;;LV Jāņu dienu,DE Mittsommertag,EN Midsummer Day
-75c8ae66-6321-40d0-82f1-674ff012a3c6;LV;2029-11-18;;Public;National;;LV Latvijas Republikas Proklamēšanas dienu,DE Tag der Ausrufung der Republik Lettland,EN Day of the Proclamation of the Republic of Latvia
+3ca8cc69-c9eb-4c55-8b1a-9f713d145d94;LV;2029-04-02;;Public;National;;LV Otrās Lieldienas,DE Ostermontag,EN Easter Monday
+69eba023-1e14-421f-a6e0-7c76e0dcf466;LV;2029-05-01;;Public;National;;LV Darba svētki,DE Tag der Arbeit,EN Labour Day
+9983f97e-e50e-4667-8805-08d81ef19701;LV;2029-05-04;;Public;National;;LV Latvijas Republikas Neatkarības atjaunošanas diena,DE Tag der Wiederherstellung der Unabhängigkeit,EN Day of the Restoration of Independence
+c7c0eeee-3d05-4efd-a8dd-14e2d9e441ff;LV;2029-05-13;;Public;National;;LV Mātes diena,DE Muttertag,EN Mother's Day
+aec65883-0e19-4b62-a292-9f0787fb1e69;LV;2029-05-20;;Public;National;;LV Vasarsvētki,DE Pfingsten,EN Pentecost
+c6fc6146-34c0-4539-825d-7844d3ebe54f;LV;2029-06-23;;Public;National;;LV Līgo diena,DE Mittsommernacht,EN Midsummer's Eve
+15ff7d0b-3e24-4ab5-91c7-0f2661fcc512;LV;2029-06-24;;Public;National;;LV Jāņu diena,DE Mittsommertag,EN Midsummer Day
+75c8ae66-6321-40d0-82f1-674ff012a3c6;LV;2029-11-18;;Public;National;;LV Latvijas Republikas Proklamēšanas diena,DE Tag der Ausrufung der Republik Lettland,EN Day of the Proclamation of the Republic of Latvia
 92ecb46e-d20f-4ce4-84ee-14c35ba0a284;LV;2029-12-24;;Public;National;;LV Ziemassvētku vakars,DE Heiligabend,EN Christmas Eve
-c67c49a3-029d-4fc9-8872-d51341ccb554;LV;2029-12-25;;Public;National;;LV Ziemassvētki,DE Weihnachten,EN Christmas Day
+c67c49a3-029d-4fc9-8872-d51341ccb554;LV;2029-12-25;;Public;National;;LV Pirmie Ziemassvētki,DE Weihnachten,EN Christmas Day
 0b24f48d-c324-473d-a0aa-085ef7aab7f8;LV;2029-12-26;;Public;National;;LV Otrie Ziemassvētki,DE 2. Weihnachtsfeiertag,EN 2nd Day of Christmas
-936825cc-f25b-4a71-98ac-60760cd0268b;LV;2029-12-31;;Public;National;;LV Vecgada dienu,DE Silvester,EN New Year's Eve
-e481fc06-b2a6-45d5-9024-00c4a3ccabcc;LV;2030-01-01;;Public;National;;LV Jaungada dienu,DE Neujahr,EN New Year's Day
-676e3a52-b542-4fac-89f0-693afbae95d0;LV;2030-04-18;;Public;National;;LV Lielo Piektdienu,DE Karfreitag,EN Good Friday
+936825cc-f25b-4a71-98ac-60760cd0268b;LV;2029-12-31;;Public;National;;LV Vecgada diena,DE Silvester,EN New Year's Eve
+e481fc06-b2a6-45d5-9024-00c4a3ccabcc;LV;2030-01-01;;Public;National;;LV Jaungada diena,DE Neujahr,EN New Year's Day
+676e3a52-b542-4fac-89f0-693afbae95d0;LV;2030-04-18;;Public;National;;LV Lielā Piektdiena,DE Karfreitag,EN Good Friday
 ded4556c-75de-48c5-9188-023b7c372af1;LV;2030-04-21;;Public;National;;LV Pirmās Lieldienas,DE Ostersonntag,EN Easter Sunday
-0678adc1-ce93-49a4-81ba-83744fc8a5ce;LV;2030-04-22;;Public;National;;LV Lieldienu dienu,DE Ostermontag,EN Easter Monday
-419e36b2-33de-4e68-a3c3-92bf12bddb5e;LV;2030-05-01;;Public;National;;LV Darba svētkus,DE Tag der Arbeit,EN Labour Day
-72135952-9d68-4f64-b75f-c30ed8764dea;LV;2030-05-04;;Public;National;;LV Latvijas Republikas Neatkarības atjaunošanas dienu,DE Tag der Wiederherstellung der Unabhängigkeit,EN Day of the Restoration of Independence
-b502e8ed-5971-4308-a1e9-fb248c171ae7;LV;2030-05-12;;Public;National;;LV Mātes dienu,DE Muttertag,EN Mother's Day
-4beb68e6-c859-40d1-853c-8243a37cf6c4;LV;2030-06-09;;Public;National;;LV Vasarsvētkus,DE Pfingsten,EN Pentecost
-9f77f04f-4d58-4c35-ab36-462dd3f0c5e6;LV;2030-06-23;;Public;National;;LV Līgo dienu,DE Mittsommernacht,EN Midsummer's Eve
-980802ba-c9b4-4581-b36f-54a95659a0f9;LV;2030-06-24;;Public;National;;LV Jāņu dienu,DE Mittsommertag,EN Midsummer Day
-a6b938f8-1f7f-4f1e-aad9-ba15e3c93301;LV;2030-11-18;;Public;National;;LV Latvijas Republikas Proklamēšanas dienu,DE Tag der Ausrufung der Republik Lettland,EN Day of the Proclamation of the Republic of Latvia
+0678adc1-ce93-49a4-81ba-83744fc8a5ce;LV;2030-04-22;;Public;National;;LV Otrās Lieldienas,DE Ostermontag,EN Easter Monday
+419e36b2-33de-4e68-a3c3-92bf12bddb5e;LV;2030-05-01;;Public;National;;LV Darba svētki,DE Tag der Arbeit,EN Labour Day
+72135952-9d68-4f64-b75f-c30ed8764dea;LV;2030-05-04;;Public;National;;LV Latvijas Republikas Neatkarības atjaunošanas diena,DE Tag der Wiederherstellung der Unabhängigkeit,EN Day of the Restoration of Independence
+b502e8ed-5971-4308-a1e9-fb248c171ae7;LV;2030-05-12;;Public;National;;LV Mātes diena,DE Muttertag,EN Mother's Day
+4beb68e6-c859-40d1-853c-8243a37cf6c4;LV;2030-06-09;;Public;National;;LV Vasarsvētki,DE Pfingsten,EN Pentecost
+9f77f04f-4d58-4c35-ab36-462dd3f0c5e6;LV;2030-06-23;;Public;National;;LV Līgo diena,DE Mittsommernacht,EN Midsummer's Eve
+980802ba-c9b4-4581-b36f-54a95659a0f9;LV;2030-06-24;;Public;National;;LV Jāņu diena,DE Mittsommertag,EN Midsummer Day
+a6b938f8-1f7f-4f1e-aad9-ba15e3c93301;LV;2030-11-18;;Public;National;;LV Latvijas Republikas Proklamēšanas diena,DE Tag der Ausrufung der Republik Lettland,EN Day of the Proclamation of the Republic of Latvia
 caca04b8-3beb-456d-81ad-def723e73675;LV;2030-12-24;;Public;National;;LV Ziemassvētku vakars,DE Heiligabend,EN Christmas Eve
-9120a03e-4746-4f62-99e6-04dcdda53b88;LV;2030-12-25;;Public;National;;LV Ziemassvētki,DE Weihnachten,EN Christmas Day
+9120a03e-4746-4f62-99e6-04dcdda53b88;LV;2030-12-25;;Public;National;;LV Pirmie Ziemassvētki,DE Weihnachten,EN Christmas Day
 957144aa-0fb0-4a50-9df5-b0b79e2bb5fc;LV;2030-12-26;;Public;National;;LV Otrie Ziemassvētki,DE 2. Weihnachtsfeiertag,EN 2nd Day of Christmas
-cb0e0fe3-aff6-4740-8761-2074f9c81b7c;LV;2030-12-31;;Public;National;;LV Vecgada dienu,DE Silvester,EN New Year's Eve
+cb0e0fe3-aff6-4740-8761-2074f9c81b7c;LV;2030-12-31;;Public;National;;LV Vecgada diena,DE Silvester,EN New Year's Eve


### PR DESCRIPTION
Latvian holiday names were stored in accusative case, copied literally
from the law "Par svētku, atceres un atzīmējamām dienām", where the
governing verb "noteikt" requires accusative case. Standalone labels
must be in nominative case.

Source: https://likumi.lv/doc.php?id=72608