### PR TITLE
feat(LV): add school holidays for 2025/2026 and 2026/2027

### DIFF
--- a/src/lv/holidays/holidays.school.csv
+++ b/src/lv/holidays/holidays.school.csv
@@ -22,3 +22,11 @@ f36b5bab-b5e0-4283-80a1-3497c00fe079;LV;2024-10-21;2024-10-27;School;National;LV
 5fc2398b-77ba-43ab-802f-bcd6a54fd979;LV;2024-12-23;2025-01-05;School;National;LV Ziemas brīvdienas,DE Winterferien,EN Winter Holidays;
 6b9c832c-8ac0-4440-bb75-a5efa167ba4e;LV;2025-03-10;2025-03-16;School;National;LV Pavasara brīvdienas,DE Frühjahrsferien,EN Spring Holidays;
 c501693b-e162-4749-86f4-37ab16972d06;LV;2025-05-31;2025-08-31;School;National;LV Vasaras brīvdienas,DE Sommerferien,EN Summer Holidays;
+071ae580-8eae-4399-a09b-09efd7aa662f;LV;2025-10-20;2025-10-24;School;National;LV Rudens brīvdienas,DE Herbstferien,EN Autumn Holidays;
+1e366cc6-1c69-48f8-ac9a-24b7b58abb13;LV;2025-12-22;2026-01-02;School;National;LV Ziemas brīvdienas,DE Winterferien,EN Winter Holidays;
+d33c43c6-fa2c-47e0-b25a-6ae5195a7af8;LV;2026-03-09;2026-03-13;School;National;LV Pavasara brīvdienas,DE Frühjahrsferien,EN Spring Holidays;
+e3012ee1-32cb-4dd5-acae-9cae06d50b36;LV;2026-06-01;2026-08-31;School;National;LV Vasaras brīvdienas,DE Sommerferien,EN Summer Holidays;
+9e7494cf-8479-40b0-8368-5abaaaacf6de;LV;2026-10-19;2026-10-23;School;National;LV Rudens brīvdienas,DE Herbstferien,EN Autumn Holidays;
+b76fc584-6d5c-47b4-afac-60ec04b23565;LV;2026-12-21;2027-01-01;School;National;LV Ziemas brīvdienas,DE Winterferien,EN Winter Holidays;
+78dc0cb0-bd2c-4e01-9ad0-db898afc8685;LV;2027-03-08;2027-03-12;School;National;LV Pavasara brīvdienas,DE Frühjahrsferien,EN Spring Holidays;
+98d52a07-818a-4c89-aff9-e977b9bcba10;LV;2027-06-01;2027-08-31;School;National;LV Vasaras brīvdienas,DE Sommerferien,EN Summer Holidays;


### PR DESCRIPTION
Latvian school holiday data in `src/lv/holidays/holidays.school.csv` currently ends at summer 2025. The sources page already cites the 2025/2026 IZM announcement, but the corresponding rows were never added — so both the 2025/2026 and 2026/2027 school years are missing.

This adds the 8 missing rows (autumn / winter / spring / summer for each year).

**Sources** — Ministry of Education and Science (IZM):

- [Apstiprināti 2025./2026. mācību gada sākuma, beigu un brīvdienu laiki](https://www.izm.gov.lv/lv/jaunums/apstiprinati-20252026-macibu-gada-sakuma-beigu-un-brivdienu-laiki)
- [Apstiprināti 2026./2027. mācību gada sākuma, beigu un brīvdienu laiki](https://www.izm.gov.lv/lv/jaunums/apstiprinati-20262027-macibu-gada-sakuma-beigu-un-brivdienu-laiki)

Dates are taken verbatim from the IZM announcements and cross-checked against the dataset I maintain at https://darbadienas.lv.

Note the summer holiday rows use the start date given for grades 1–8 and 10–11, consistent with the existing rows for earlier years (9th and 12th grade finish later).

`bin/test_all_tables.py` passes locally. New UUIDs checked for collisions against all 14061 existing IDs in the repo.

If it would help, I'm happy to also open a PR adding the 2026/2027 IZM link to the sources page.
