### PR TITLE
feat(SI): add school holidays for 2026/2027

### DIFF
--- a/src/si/holidays/holidays.school.csv
+++ b/src/si/holidays/holidays.school.csv
@@ -53,3 +53,12 @@ e157f40c-996c-43bf-bf73-02b0f68ce773;SI;2026-02-16;2026-02-20;School;Regional;SL
 a9804371-009a-4b89-a1b4-46c210ad0d7f;SI;2026-04-27;2026-05-01;School;National;SL Prvomajske počitnice,DE Maifeiertage,EN Maydays;;SL osnovne šole,DE Grundschulen,EN Primary schools
 9c2ab2b0-daec-43f1-837f-21002b8b5178;SI;2026-04-28;2026-04-30;School;National;SL Prvomajske počitnice,DE Maifeiertage,EN Maydays;;SL srednje šole,DE Sekundarschulen,EN Secondary schools
 5a3966d7-1158-483a-b67f-6ff85eaf3683;SI;2026-06-26;2026-08-31;School;National;SL Poletne počitnice,DE Sommerferien,EN Summer holidays;;
+de41834a-519c-4a2f-8659-44f0bfc4ea0b;SI;2026-10-26;2026-10-30;School;National;SL Jesenske počitnice,DE Herbstferien,EN Autumn holidays;;
+febee5f6-79f0-4cc1-9418-6a85c17a377d;SI;2026-12-25;2027-01-02;School;National;SL Novoletne počitnice,DE Neujahrsferien,EN New Year holidays;;SL osnovne šole,DE Grundschulen,EN Primary schools
+13e89d48-1fc7-4b13-837d-aa1ce290b530;SI;2026-12-28;2026-12-31;School;National;SL Novoletne počitnice,DE Neujahrsferien,EN New Year holidays;;SL srednje šole,DE Sekundarschulen,EN Secondary schools
+7800129c-71e0-4011-a8c0-cc5742a4e028;SI;2027-02-15;2027-02-19;School;Regional;SL Zimske počitnice,DE Winterferien,EN Winter holidays;VR;
+e69206dc-9542-4f33-8c29-e3138531730b;SI;2027-02-22;2027-02-26;School;Regional;SL Zimske počitnice,DE Winterferien,EN Winter holidays;ZR;
+c870ad21-25ff-4c01-8b86-8a9e6442f90d;SI;2027-04-26;;School;National;SL Pouka prost dan,DE Schulfreier Tag,EN Day off school;;
+530ea1b8-794a-4a00-9f47-00edfcd2458e;SI;2027-04-27;2027-05-02;School;National;SL Prvomajske počitnice,DE Maifeiertage,EN Maydays;;SL osnovne šole,DE Grundschulen,EN Primary schools
+e1390454-30a8-410d-9993-aab999a7d0ff;SI;2027-04-28;2027-04-30;School;National;SL Prvomajske počitnice,DE Maifeiertage,EN Maydays;;SL srednje šole,DE Sekundarschulen,EN Secondary schools
+f82944f9-0b88-4a49-a463-946105e77193;SI;2027-06-28;2027-08-31;School;National;SL Poletne počitnice,DE Sommerferien,EN Summer holidays;;


### PR DESCRIPTION
`src/si/holidays/holidays.school.csv` stops at the 2025/2026 summer break, so a query for any date in the 2026/2027 school year comes back empty. The ministry settled that year's calendar in February (primary) and April (secondary) 2026.

These 9 rows complete it.

| Start | End | Holiday | Scope |
|---|---|---|---|
| 2026-10-26 | 2026-10-30 | Jesenske počitnice | national |
| 2026-12-25 | 2027-01-02 | Novoletne počitnice | national, primary |
| 2026-12-28 | 2026-12-31 | Novoletne počitnice | national, secondary |
| 2027-02-15 | 2027-02-19 | Zimske počitnice | VR |
| 2027-02-22 | 2027-02-26 | Zimske počitnice | ZR |
| 2027-04-26 | — | Pouka prost dan | national |
| 2027-04-27 | 2027-05-02 | Prvomajske počitnice | national, primary |
| 2027-04-28 | 2027-04-30 | Prvomajske počitnice | national, secondary |
| 2027-06-28 | 2027-08-31 | Poletne počitnice | national |

### Sources

Both are ministerial instructions issued under the respective *Pravilnik o šolskem koledarju*:

- Primary — [Podrobnejša navodila o šolskem koledarju za osnovne šole za šolsko leto 2026/2027](https://www.gov.si/assets/ministrstva/MVI/Dokumenti/Osnovna-sola/Solski-koledar/2026_2027/Podrobnejsa-navodila-o-solskem-koledarju-za-OS-za-sol-leto-2026-2027.pdf), no. 6034-11/2026-3350-1, 5 Feb 2026 ([index](https://www.gov.si/teme/solski-koledar-za-osnovne-sole/))
- Secondary — [Počitnice in pouka prosti dnevi … za šolsko leto 2026/2027](https://www.gov.si/assets/ministrstva/MVI/Dokumenti/Srednja-sola/Solski-koledar/Solski-koledar-2026-2027/Pocitnice-in-pouka-prosti-dnevi-izpitni-roki-okvirni-koledar-splosne-in-poklicne-mature-ter-zakljucnega-izpita-za-2026-2027.pdf), no. 6036-181/2026-3350-1, 23 Apr 2026 ([index](https://www.gov.si/teme/solski-koledar-za-srednje-sole/))

Every date is read off those two documents. None is carried forward from a previous year, which matters because two of them break the usual pattern:

- **Summer starts on the 28th, not the 26th.** Slovenian summer holidays have begun on 26 June for years, but 26 June 2027 is a Saturday, so the ministry set the Monday.
- **The winter regions are the other way round from last year.** For 2026/2027 VR runs 15–19 February and ZR runs 22–26; in 2025/2026 it was ZR first. The two halves alternate annually, so anyone extrapolating from the existing rows would put both regions on the wrong week.

### One caveat about Kočevje

The two documents disagree on it. The secondary-school calendar excludes Kočevje from the 15–19 February group along with Ribnica, Sodražica, Loški Potok, Osilnica and Kostel; the primary-school calendar lists those five but not Kočevje. So Kočevje's primary schools take the earlier week and its secondary schools the later one.

`subdivisions.csv` maps Kočevje to `ZR`, which matches the secondary reading. A single `VR`/`ZR` tag per municipality can't express a split that depends on school type, so I've left the mapping alone and these rows follow it — flagging it rather than working around it, since it predates this change and affects one municipality.

### Checks

`bin/test_all_tables.py` passes on the modified tree. The 9 UUIDs are freshly generated and don't collide with any of the 14,061 IDs already in the repository. Rows are appended in date order, the file keeps its BOM and LF endings, and all six holiday names already exist in the file, so no new name strings are introduced.
