### PR TITLE
fix(be): classify Easter Sundays as optional

### DIFF
--- a/src/be/holidays/holidays.public.csv
+++ b/src/be/holidays/holidays.public.csv
@@ -1,10 +1,10 @@
 ﻿Id;Country;StartDate;EndDate;Type;RegionalScope;Name
 78465c35-9dbd-458b-bd38-ea8105d9d9d0;BE;2020-01-01;;Public;National;FR Jour de l'an,NL Nieuwjaarsdag,DE Neujahrstag,EN New Year's Day
-a5f2914b-a5d2-4883-a576-893a1f4e194d;BE;2020-04-12;;Public;National;FR Pâques,NL Pasen,DE Ostern,EN Easter
+a5f2914b-a5d2-4883-a576-893a1f4e194d;BE;2020-04-12;;Optional;National;FR Pâques,NL Pasen,DE Ostern,EN Easter
 b171e19e-24b4-4a06-9072-a8d2867a46f9;BE;2020-04-13;;Public;National;FR Lundi de Pâques,NL Paasmaandag,DE Ostermontag,EN Easter Monday
 53c077ec-4b89-4c7e-9122-4d0d386dda84;BE;2020-05-01;;Public;National;FR Fête du Travail,NL Dag van de Arbeid,DE Tag der Arbeit,EN Labour Day
 7b7802d7-7176-4145-929e-b83496da5a6b;BE;2020-05-21;;Public;National;FR Ascension,NL O.L.H. Hemelvaart,DE Christi Himmelfahrt,EN Ascension Day
-a5fe22f6-fa91-464b-845d-c4431a3eef24;BE;2020-05-31;;Public;National;FR Pentecôte,NL Pinksteren,DE Pfingsten,EN Pentecost
+a5fe22f6-fa91-464b-845d-c4431a3eef24;BE;2020-05-31;;Optional;National;FR Pentecôte,NL Pinksteren,DE Pfingsten,EN Pentecost
 f4039a1b-540b-42fb-8951-05d918f0c865;BE;2020-06-01;;Public;National;FR Lundi de Pentecôte,NL Pinkstermaandag,DE Pfingstmontag,EN Pentecost Monday
 98c46766-79a3-413b-8366-e64e32b697e6;BE;2020-07-21;;Public;National;FR Fête nationale,NL Nationale feestdag,DE Nationalfeiertag,EN National Day
 4ce82711-6790-4f7d-a3c9-fdef48fe2757;BE;2020-08-15;;Public;National;FR Assomption,NL O.L.V. Hemelvaart,DE Mariä Himmelfahrt,EN Assumption Day
@@ -12,11 +12,11 @@ f4039a1b-540b-42fb-8951-05d918f0c865;BE;2020-06-01;;Public;National;FR Lundi de 
 64b8f5e0-76a8-4283-9a4d-02a8b58deb8d;BE;2020-11-11;;Public;National;FR Armistice de 1918,NL Wapenstilstand van 1918,DE Waffenstillstand,EN Armistice Day
 085f1c2c-1a6a-438c-afb7-23205dafb49d;BE;2020-12-25;;Public;National;FR Noël,NL Kerstmis,DE Weihnachten,EN Christmas Day
 dd0eca69-299b-40a8-b934-139a68a35330;BE;2021-01-01;;Public;National;FR Jour de l'an,NL Nieuwjaarsdag,DE Neujahrstag,EN New Year's Day
-05689c65-734d-400d-bfb8-08713109cfe3;BE;2021-04-04;;Public;National;FR Pâques,NL Pasen,DE Ostern,EN Easter
+05689c65-734d-400d-bfb8-08713109cfe3;BE;2021-04-04;;Optional;National;FR Pâques,NL Pasen,DE Ostern,EN Easter
 06cf2264-4976-467c-b29c-3369a63b7b03;BE;2021-04-05;;Public;National;FR Lundi de Pâques,NL Paasmaandag,DE Ostermontag,EN Easter Monday
 ac9977af-a22e-43b2-a64a-ac05860ef29e;BE;2021-05-01;;Public;National;FR Fête du Travail,NL Dag van de Arbeid,DE Tag der Arbeit,EN Labour Day
 55183618-a396-4afa-88ba-6a1c52514cb2;BE;2021-05-13;;Public;National;FR Ascension,NL O.L.H. Hemelvaart,DE Christi Himmelfahrt,EN Ascension Day
-f7765a92-a05b-477c-9a7f-8cca7cd7aeb0;BE;2021-05-23;;Public;National;FR Pentecôte,NL Pinksteren,DE Pfingsten,EN Pentecost
+f7765a92-a05b-477c-9a7f-8cca7cd7aeb0;BE;2021-05-23;;Optional;National;FR Pentecôte,NL Pinksteren,DE Pfingsten,EN Pentecost
 d33b72f3-3a7a-46cc-84d5-7c8769a81cc1;BE;2021-05-24;;Public;National;FR Lundi de Pentecôte,NL Pinkstermaandag,DE Pfingstmontag,EN Pentecost Monday
 8914b784-9206-4651-9f83-c1e6f18e761a;BE;2021-07-21;;Public;National;FR Fête nationale,NL Nationale feestdag,DE Nationalfeiertag,EN National Day
 3edbeb56-7527-4891-9ac7-84dda9884fac;BE;2021-08-15;;Public;National;FR Assomption,NL O.L.V. Hemelvaart,DE Mariä Himmelfahrt,EN Assumption Day
@@ -24,11 +24,11 @@ d33b72f3-3a7a-46cc-84d5-7c8769a81cc1;BE;2021-05-24;;Public;National;FR Lundi de 
 82da511f-7b72-47dc-82ee-9754e506a490;BE;2021-11-11;;Public;National;FR Armistice de 1918,NL Wapenstilstand van 1918,DE Waffenstillstand,EN Armistice Day
 833b3227-64a3-470f-9512-7ec3506675e4;BE;2021-12-25;;Public;National;FR Noël,NL Kerstmis,DE Weihnachten,EN Christmas Day
 d92c2b46-e752-455d-9f7b-d6332b39bce6;BE;2022-01-01;;Public;National;FR Jour de l'an,NL Nieuwjaarsdag,DE Neujahrstag,EN New Year's Day
-908d2be5-e592-4479-9f92-19e2c1d22854;BE;2022-04-17;;Public;National;FR Pâques,NL Pasen,DE Ostern,EN Easter
+908d2be5-e592-4479-9f92-19e2c1d22854;BE;2022-04-17;;Optional;National;FR Pâques,NL Pasen,DE Ostern,EN Easter
 34b47e4e-b51f-4399-b92f-0fa12b9260e7;BE;2022-04-18;;Public;National;FR Lundi de Pâques,NL Paasmaandag,DE Ostermontag,EN Easter Monday
 98aa516f-47d5-4e9d-a370-7ce34b07076f;BE;2022-05-01;;Public;National;FR Fête du Travail,NL Dag van de Arbeid,DE Tag der Arbeit,EN Labour Day
 526c2211-6a71-414d-9a63-a2b5859bf943;BE;2022-05-26;;Public;National;FR Ascension,NL O.L.H. Hemelvaart,DE Christi Himmelfahrt,EN Ascension Day
-2a09f6bd-2fc6-46f4-aec8-c010d881ec5c;BE;2022-06-05;;Public;National;FR Pentecôte,NL Pinksteren,DE Pfingsten,EN Pentecost
+2a09f6bd-2fc6-46f4-aec8-c010d881ec5c;BE;2022-06-05;;Optional;National;FR Pentecôte,NL Pinksteren,DE Pfingsten,EN Pentecost
 76c8aa9c-778f-4096-9f52-47c7ccbee128;BE;2022-06-06;;Public;National;FR Lundi de Pentecôte,NL Pinkstermaandag,DE Pfingstmontag,EN Pentecost Monday
 ebde0b4c-6df2-4344-88fc-0841948f161a;BE;2022-07-21;;Public;National;FR Fête nationale,NL Nationale feestdag,DE Nationalfeiertag,EN National Day
 3bb25711-a3e6-44f3-b12a-adc6460b2ea8;BE;2022-08-15;;Public;National;FR Assomption,NL O.L.V. Hemelvaart,DE Mariä Himmelfahrt,EN Assumption Day
@@ -36,11 +36,11 @@ ebde0b4c-6df2-4344-88fc-0841948f161a;BE;2022-07-21;;Public;National;FR Fête nat
 7b7467c2-6f2d-43ea-9175-095ae60a1a2d;BE;2022-11-11;;Public;National;FR Armistice de 1918,NL Wapenstilstand van 1918,DE Waffenstillstand,EN Armistice Day
 e1d34f1d-bb63-4b6d-be64-f91ff705d0bd;BE;2022-12-25;;Public;National;FR Noël,NL Kerstmis,DE Weihnachten,EN Christmas Day
 3d3fdf44-4e12-4a22-8c2a-943293871031;BE;2023-01-01;;Public;National;FR Jour de l'an,NL Nieuwjaarsdag,DE Neujahrstag,EN New Year's Day
-cc4bbf3a-e9fb-4a07-a3a5-32ed1a992f4e;BE;2023-04-09;;Public;National;FR Pâques,NL Pasen,DE Ostern,EN Easter
+cc4bbf3a-e9fb-4a07-a3a5-32ed1a992f4e;BE;2023-04-09;;Optional;National;FR Pâques,NL Pasen,DE Ostern,EN Easter
 9d1a20b9-5ae8-4f45-9473-d59622e9327e;BE;2023-04-10;;Public;National;FR Lundi de Pâques,NL Paasmaandag,DE Ostermontag,EN Easter Monday
 f9bc61d2-2f79-4aab-a4a0-44d984e03a6b;BE;2023-05-01;;Public;National;FR Fête du Travail,NL Dag van de Arbeid,DE Tag der Arbeit,EN Labour Day
 34fe79fb-d513-42d0-8141-7bdf4e23a1ea;BE;2023-05-18;;Public;National;FR Ascension,NL O.L.H. Hemelvaart,DE Christi Himmelfahrt,EN Ascension Day
-427ebbbd-67f1-4b22-a7b6-2feb1f0d3935;BE;2023-05-28;;Public;National;FR Pentecôte,NL Pinksteren,DE Pfingsten,EN Pentecost
+427ebbbd-67f1-4b22-a7b6-2feb1f0d3935;BE;2023-05-28;;Optional;National;FR Pentecôte,NL Pinksteren,DE Pfingsten,EN Pentecost
 b839037a-2587-4271-895f-56b356f0f73b;BE;2023-05-29;;Public;National;FR Lundi de Pentecôte,NL Pinkstermaandag,DE Pfingstmontag,EN Pentecost Monday
 0fd14f87-fe8f-45c8-a3b5-fa01145bfb2b;BE;2023-07-21;;Public;National;FR Fête nationale,NL Nationale feestdag,DE Nationalfeiertag,EN National Day
 4760c29d-01e1-4e04-9063-fe8d47ba4761;BE;2023-08-15;;Public;National;FR Assomption,NL O.L.V. Hemelvaart,DE Mariä Himmelfahrt,EN Assumption Day
@@ -48,11 +48,11 @@ f0733c4b-b4a2-4d1b-bfca-60778732875f;BE;2023-11-01;;Public;National;FR Toussaint
 5c4cd8de-08fa-4ec0-9461-9309e50d8c6d;BE;2023-11-11;;Public;National;FR Armistice de 1918,NL Wapenstilstand van 1918,DE Waffenstillstand,EN Armistice Day
 bc1f0bcb-4956-459b-920a-2eae2b2ae5d8;BE;2023-12-25;;Public;National;FR Noël,NL Kerstmis,DE Weihnachten,EN Christmas Day
 d3571b8a-8d12-42b7-9fd8-34ab6ba29af4;BE;2024-01-01;;Public;National;FR Jour de l'an,NL Nieuwjaarsdag,DE Neujahrstag,EN New Year's Day
-fc163490-cfaa-4dff-aada-a2dfffd80d40;BE;2024-03-31;;Public;National;FR Pâques,NL Pasen,DE Ostern,EN Easter
+fc163490-cfaa-4dff-aada-a2dfffd80d40;BE;2024-03-31;;Optional;National;FR Pâques,NL Pasen,DE Ostern,EN Easter
 a353d8d7-5927-4992-8553-d16589803c54;BE;2024-04-01;;Public;National;FR Lundi de Pâques,NL Paasmaandag,DE Ostermontag,EN Easter Monday
 f7f764d2-8291-4f8a-82c3-887891e58cf9;BE;2024-05-01;;Public;National;FR Fête du Travail,NL Dag van de Arbeid,DE Tag der Arbeit,EN Labour Day
 ff3b1823-3b95-4f3b-a5e3-80f4bbd270d0;BE;2024-05-09;;Public;National;FR Ascension,NL O.L.H. Hemelvaart,DE Christi Himmelfahrt,EN Ascension Day
-f7caeb89-3411-4c73-90fb-4e94948ab004;BE;2024-05-19;;Public;National;FR Pentecôte,NL Pinksteren,DE Pfingsten,EN Pentecost
+f7caeb89-3411-4c73-90fb-4e94948ab004;BE;2024-05-19;;Optional;National;FR Pentecôte,NL Pinksteren,DE Pfingsten,EN Pentecost
 cdbcac62-e2b7-41f3-83e0-b0db65cb982e;BE;2024-05-20;;Public;National;FR Lundi de Pentecôte,NL Pinkstermaandag,DE Pfingstmontag,EN Pentecost Monday
 3e119382-f32d-40db-b432-8ed9bfa0f914;BE;2024-07-21;;Public;National;FR Fête nationale,NL Nationale feestdag,DE Nationalfeiertag,EN National Day
 84be67b7-5928-45bd-a9bb-617301ff6977;BE;2024-08-15;;Public;National;FR Assomption,NL O.L.V. Hemelvaart,DE Mariä Himmelfahrt,EN Assumption Day
@@ -60,11 +60,11 @@ cdbcac62-e2b7-41f3-83e0-b0db65cb982e;BE;2024-05-20;;Public;National;FR Lundi de 
 59e5de5f-ddb8-4c7d-bc48-b5c19f6d8c61;BE;2024-11-11;;Public;National;FR Armistice de 1918,NL Wapenstilstand van 1918,DE Waffenstillstand,EN Armistice Day
 0e4856e0-9bc8-4e2a-b1d5-9df666569fdf;BE;2024-12-25;;Public;National;FR Noël,NL Kerstmis,DE Weihnachten,EN Christmas Day
 ce86dab3-99dd-404b-b874-c572914bf7f8;BE;2025-01-01;;Public;National;FR Jour de l'an,NL Nieuwjaarsdag,DE Neujahrstag,EN New Year's Day
-a75afd22-8aed-49bd-9b55-04666d454fe0;BE;2025-04-20;;Public;National;FR Pâques,NL Pasen,DE Ostern,EN Easter
+a75afd22-8aed-49bd-9b55-04666d454fe0;BE;2025-04-20;;Optional;National;FR Pâques,NL Pasen,DE Ostern,EN Easter
 bf2b1518-6be2-4b61-b387-bc5d72e3c2fe;BE;2025-04-21;;Public;National;FR Lundi de Pâques,NL Paasmaandag,DE Ostermontag,EN Easter Monday
 2dae2e0c-bf77-4b6d-9956-a88e400ac504;BE;2025-05-01;;Public;National;FR Fête du Travail,NL Dag van de Arbeid,DE Tag der Arbeit,EN Labour Day
 e2c5baff-1c75-4604-8413-b694a53459d8;BE;2025-05-29;;Public;National;FR Ascension,NL O.L.H. Hemelvaart,DE Christi Himmelfahrt,EN Ascension Day
-ae6f662f-ed24-461b-9617-fea2ff906d45;BE;2025-06-08;;Public;National;FR Pentecôte,NL Pinksteren,DE Pfingsten,EN Pentecost
+ae6f662f-ed24-461b-9617-fea2ff906d45;BE;2025-06-08;;Optional;National;FR Pentecôte,NL Pinksteren,DE Pfingsten,EN Pentecost
 eab43344-466e-4e19-8886-3013bb77821a;BE;2025-06-09;;Public;National;FR Lundi de Pentecôte,NL Pinkstermaandag,DE Pfingstmontag,EN Pentecost Monday
 22bc516a-0b83-454a-9fb8-71f6799d1f8e;BE;2025-07-21;;Public;National;FR Fête nationale,NL Nationale feestdag,DE Nationalfeiertag,EN National Day
 6c1155ac-5e3b-4d82-9f91-93eb7fa2977f;BE;2025-08-15;;Public;National;FR Assomption,NL O.L.V. Hemelvaart,DE Mariä Himmelfahrt,EN Assumption Day
@@ -72,11 +72,11 @@ eab43344-466e-4e19-8886-3013bb77821a;BE;2025-06-09;;Public;National;FR Lundi de 
 adebe2b2-2a40-42b1-861f-f112e46f42b3;BE;2025-11-11;;Public;National;FR Armistice de 1918,NL Wapenstilstand van 1918,DE Waffenstillstand,EN Armistice Day
 cbb3e717-90bc-4df1-8b72-e86f370f1284;BE;2025-12-25;;Public;National;FR Noël,NL Kerstmis,DE Weihnachten,EN Christmas Day
 ed5688ab-e8f6-48e5-ba56-505962770355;BE;2026-01-01;;Public;National;FR Jour de l'an,NL Nieuwjaarsdag,DE Neujahrstag,EN New Year's Day
-54ce9b56-55bf-4a92-9134-c111bcbd1abf;BE;2026-04-05;;Public;National;FR Pâques,NL Pasen,DE Ostern,EN Easter
+54ce9b56-55bf-4a92-9134-c111bcbd1abf;BE;2026-04-05;;Optional;National;FR Pâques,NL Pasen,DE Ostern,EN Easter
 63ef9e69-f2d3-4165-9bc4-6bcf5e32a6a0;BE;2026-04-06;;Public;National;FR Lundi de Pâques,NL Paasmaandag,DE Ostermontag,EN Easter Monday
 baa20ef3-b64a-417f-b42d-2cef313b2ef1;BE;2026-05-01;;Public;National;FR Fête du Travail,NL Dag van de Arbeid,DE Tag der Arbeit,EN Labour Day
 ce16ed86-4327-42ea-b165-9f787258934b;BE;2026-05-14;;Public;National;FR Ascension,NL O.L.H. Hemelvaart,DE Christi Himmelfahrt,EN Ascension Day
-48a27bde-b58d-4d42-bca5-7175db5dfe30;BE;2026-05-24;;Public;National;FR Pentecôte,NL Pinksteren,DE Pfingsten,EN Pentecost
+48a27bde-b58d-4d42-bca5-7175db5dfe30;BE;2026-05-24;;Optional;National;FR Pentecôte,NL Pinksteren,DE Pfingsten,EN Pentecost
 fbaf2bb4-46fb-4320-8cf4-30b63744382a;BE;2026-05-25;;Public;National;FR Lundi de Pentecôte,NL Pinkstermaandag,DE Pfingstmontag,EN Pentecost Monday
 f28f2051-d438-4a0f-952e-656bce7d984f;BE;2026-07-21;;Public;National;FR Fête nationale,NL Nationale feestdag,DE Nationalfeiertag,EN National Day
 a13dcc3e-2f9a-4752-af93-f2ba4715e8a5;BE;2026-08-15;;Public;National;FR Assomption,NL O.L.V. Hemelvaart,DE Mariä Himmelfahrt,EN Assumption Day
@@ -84,11 +84,11 @@ a13dcc3e-2f9a-4752-af93-f2ba4715e8a5;BE;2026-08-15;;Public;National;FR Assomptio
 b1c5d2c0-edfb-4ec7-b81c-68b485497792;BE;2026-11-11;;Public;National;FR Armistice de 1918,NL Wapenstilstand van 1918,DE Waffenstillstand,EN Armistice Day
 d90e5f53-bc92-4860-bdae-f7e75935848d;BE;2026-12-25;;Public;National;FR Noël,NL Kerstmis,DE Weihnachten,EN Christmas Day
 50263674-342f-40a2-b766-04838785bef2;BE;2027-01-01;;Public;National;FR Jour de l'an,NL Nieuwjaarsdag,DE Neujahrstag,EN New Year's Day
-fa2d43d6-cb04-4038-b58b-e24d05c55db7;BE;2027-03-28;;Public;National;FR Pâques,NL Pasen,DE Ostern,EN Easter
+fa2d43d6-cb04-4038-b58b-e24d05c55db7;BE;2027-03-28;;Optional;National;FR Pâques,NL Pasen,DE Ostern,EN Easter
 3276cc7a-461c-4e1f-82c2-62fc030dc88e;BE;2027-03-29;;Public;National;FR Lundi de Pâques,NL Paasmaandag,DE Ostermontag,EN Easter Monday
 5778ed93-f03f-427b-a93c-2b1d45f52fff;BE;2027-05-01;;Public;National;FR Fête du Travail,NL Dag van de Arbeid,DE Tag der Arbeit,EN Labour Day
 62d379f8-32f2-4e89-a4de-8e6201fb2c98;BE;2027-05-06;;Public;National;FR Ascension,NL O.L.H. Hemelvaart,DE Christi Himmelfahrt,EN Ascension Day
-0a43f66e-b2e4-43ef-9b4d-ee554ae05674;BE;2027-05-16;;Public;National;FR Pentecôte,NL Pinksteren,DE Pfingsten,EN Pentecost
+0a43f66e-b2e4-43ef-9b4d-ee554ae05674;BE;2027-05-16;;Optional;National;FR Pentecôte,NL Pinksteren,DE Pfingsten,EN Pentecost
 54323103-a61c-4bec-a8a0-5fc2dce02bf9;BE;2027-05-17;;Public;National;FR Lundi de Pentecôte,NL Pinkstermaandag,DE Pfingstmontag,EN Pentecost Monday
 a568cedc-09ca-498c-8b17-cadf99447681;BE;2027-07-21;;Public;National;FR Fête nationale,NL Nationale feestdag,DE Nationalfeiertag,EN National Day
 b7175c3c-2357-4f50-a388-7db50e3f7e3c;BE;2027-08-15;;Public;National;FR Assomption,NL O.L.V. Hemelvaart,DE Mariä Himmelfahrt,EN Assumption Day
@@ -96,11 +96,11 @@ b7175c3c-2357-4f50-a388-7db50e3f7e3c;BE;2027-08-15;;Public;National;FR Assomptio
 96cfade2-b8b3-4178-95c0-0b0864005185;BE;2027-11-11;;Public;National;FR Armistice de 1918,NL Wapenstilstand van 1918,DE Waffenstillstand,EN Armistice Day
 ab2fcc8b-e597-4e22-b56f-61dba8876f14;BE;2027-12-25;;Public;National;FR Noël,NL Kerstmis,DE Weihnachten,EN Christmas Day
 95f58102-4ac1-4c2c-9945-e3ca937c966f;BE;2028-01-01;;Public;National;FR Jour de l'an,NL Nieuwjaarsdag,DE Neujahrstag,EN New Year's Day
-93ad0bd1-9784-42ef-bb54-09f478bd7874;BE;2028-04-16;;Public;National;FR Pâques,NL Pasen,DE Ostern,EN Easter
+93ad0bd1-9784-42ef-bb54-09f478bd7874;BE;2028-04-16;;Optional;National;FR Pâques,NL Pasen,DE Ostern,EN Easter
 e2d5b785-2e4d-4b50-86f5-431a02059aea;BE;2028-04-17;;Public;National;FR Lundi de Pâques,NL Paasmaandag,DE Ostermontag,EN Easter Monday
 6a0ebaea-7428-4123-9443-17ae7cd4dea1;BE;2028-05-01;;Public;National;FR Fête du Travail,NL Dag van de Arbeid,DE Tag der Arbeit,EN Labour Day
 177b7a10-f1c4-4ccf-9f15-e3503a76c443;BE;2028-05-25;;Public;National;FR Ascension,NL O.L.H. Hemelvaart,DE Christi Himmelfahrt,EN Ascension Day
-4d2e87cb-3342-48d2-a612-912a3a4681e9;BE;2028-06-04;;Public;National;FR Pentecôte,NL Pinksteren,DE Pfingsten,EN Pentecost
+4d2e87cb-3342-48d2-a612-912a3a4681e9;BE;2028-06-04;;Optional;National;FR Pentecôte,NL Pinksteren,DE Pfingsten,EN Pentecost
 a207572b-f29c-4f61-a61f-a4cd0ec2cd52;BE;2028-06-05;;Public;National;FR Lundi de Pentecôte,NL Pinkstermaandag,DE Pfingstmontag,EN Pentecost Monday
 52b49760-cbb4-4e2d-a55b-46b07d91db68;BE;2028-07-21;;Public;National;FR Fête nationale,NL Nationale feestdag,DE Nationalfeiertag,EN National Day
 7dd6cb21-5f10-4a9e-8dcd-ec5b14bf80ca;BE;2028-08-15;;Public;National;FR Assomption,NL O.L.V. Hemelvaart,DE Mariä Himmelfahrt,EN Assumption Day
@@ -108,11 +108,11 @@ a207572b-f29c-4f61-a61f-a4cd0ec2cd52;BE;2028-06-05;;Public;National;FR Lundi de 
 199bdb30-7b97-444e-b894-80b578c8cf9c;BE;2028-11-11;;Public;National;FR Armistice de 1918,NL Wapenstilstand van 1918,DE Waffenstillstand,EN Armistice Day
 3aa6fbb5-acb7-4913-ac43-f983db4b886a;BE;2028-12-25;;Public;National;FR Noël,NL Kerstmis,DE Weihnachten,EN Christmas Day
 46341586-8dc9-43a1-a93b-82fcde9ec769;BE;2029-01-01;;Public;National;FR Jour de l'an,NL Nieuwjaarsdag,DE Neujahrstag,EN New Year's Day
-e1f43758-2383-4d39-af73-618d72eb02c5;BE;2029-04-01;;Public;National;FR Pâques,NL Pasen,DE Ostern,EN Easter
+e1f43758-2383-4d39-af73-618d72eb02c5;BE;2029-04-01;;Optional;National;FR Pâques,NL Pasen,DE Ostern,EN Easter
 15e2d419-f199-4f96-b201-ee165b51fa68;BE;2029-04-02;;Public;National;FR Lundi de Pâques,NL Paasmaandag,DE Ostermontag,EN Easter Monday
 f06fa1dd-8b86-4f1d-a9dd-9bfb5a75a560;BE;2029-05-01;;Public;National;FR Fête du Travail,NL Dag van de Arbeid,DE Tag der Arbeit,EN Labour Day
 d88932bc-092e-48a0-904a-3a7cb4ac7af9;BE;2029-05-10;;Public;National;FR Ascension,NL O.L.H. Hemelvaart,DE Christi Himmelfahrt,EN Ascension Day
-5aeafbde-9497-40f7-a135-7bae321a033b;BE;2029-05-20;;Public;National;FR Pentecôte,NL Pinksteren,DE Pfingsten,EN Pentecost
+5aeafbde-9497-40f7-a135-7bae321a033b;BE;2029-05-20;;Optional;National;FR Pentecôte,NL Pinksteren,DE Pfingsten,EN Pentecost
 8e1a0f00-7415-4379-82b3-8ac0f980b638;BE;2029-05-21;;Public;National;FR Lundi de Pentecôte,NL Pinkstermaandag,DE Pfingstmontag,EN Pentecost Monday
 98ce63f0-e22e-48df-a52d-699c02beb05f;BE;2029-07-21;;Public;National;FR Fête nationale,NL Nationale feestdag,DE Nationalfeiertag,EN National Day
 e67f61f1-0d6a-4185-9277-fba96c1ca17b;BE;2029-08-15;;Public;National;FR Assomption,NL O.L.V. Hemelvaart,DE Mariä Himmelfahrt,EN Assumption Day
@@ -120,11 +120,11 @@ e67f61f1-0d6a-4185-9277-fba96c1ca17b;BE;2029-08-15;;Public;National;FR Assomptio
 32ec5ca5-48b8-4dc1-898c-f5a0d1f64673;BE;2029-11-11;;Public;National;FR Armistice de 1918,NL Wapenstilstand van 1918,DE Waffenstillstand,EN Armistice Day
 1c129dfd-c260-440a-9aac-0d21d8e3b984;BE;2029-12-25;;Public;National;FR Noël,NL Kerstmis,DE Weihnachten,EN Christmas Day
 c5c20a1b-36ed-4cc1-99f4-5802a867cd9a;BE;2030-01-01;;Public;National;FR Jour de l'an,NL Nieuwjaarsdag,DE Neujahrstag,EN New Year's Day
-d27b2517-1ed2-4a8f-949e-2a7cd4026cdf;BE;2030-04-21;;Public;National;FR Pâques,NL Pasen,DE Ostern,EN Easter
+d27b2517-1ed2-4a8f-949e-2a7cd4026cdf;BE;2030-04-21;;Optional;National;FR Pâques,NL Pasen,DE Ostern,EN Easter
 3de26b13-2aaa-4ad6-a08f-dcc45b268d2d;BE;2030-04-22;;Public;National;FR Lundi de Pâques,NL Paasmaandag,DE Ostermontag,EN Easter Monday
 ad323db0-583d-4e42-8355-e4f293d98bb0;BE;2030-05-01;;Public;National;FR Fête du Travail,NL Dag van de Arbeid,DE Tag der Arbeit,EN Labour Day
 c5b9faef-3c3d-42ac-b3c5-234efc2a3ed6;BE;2030-05-30;;Public;National;FR Ascension,NL O.L.H. Hemelvaart,DE Christi Himmelfahrt,EN Ascension Day
-a6c2bf77-3f52-4742-ab25-b00f2115e998;BE;2030-06-09;;Public;National;FR Pentecôte,NL Pinksteren,DE Pfingsten,EN Pentecost
+a6c2bf77-3f52-4742-ab25-b00f2115e998;BE;2030-06-09;;Optional;National;FR Pentecôte,NL Pinksteren,DE Pfingsten,EN Pentecost
 c21631d2-a11c-4616-8b05-9af9266e3a32;BE;2030-06-10;;Public;National;FR Lundi de Pentecôte,NL Pinkstermaandag,DE Pfingstmontag,EN Pentecost Monday
 28cebb26-d682-45db-a444-73d4cbee609a;BE;2030-07-21;;Public;National;FR Fête nationale,NL Nationale feestdag,DE Nationalfeiertag,EN National Day
 634a88fd-60f6-4ab5-ac53-b74a1c3d2139;BE;2030-08-15;;Public;National;FR Assomption,NL O.L.V. Hemelvaart,DE Mariä Himmelfahrt,EN Assumption Day


### PR DESCRIPTION
Updated Belgium’s holiday data based on the official Belgian employment authority.

Easter Sunday and Pentecost Sunday are now classified as optional rather than public holidays, matching Belgium’s list of ten statutory holidays. This should matter for people who work on Sundays.

Would it be preferable to remove these entries entirely instead, since they are not statutory holidays?

Source:
https://emploi.belgique.be/fr/themes/international/detachement/conditions-de-travail-respecter-en-cas-de-detachement-en-2