### PR TITLE
feat(FR): add Corsica school holidays for 2026-2027

### DIFF
--- a/src/fr/holidays/holidays.school.co.csv
+++ b/src/fr/holidays/holidays.school.co.csv
@@ -38,3 +38,8 @@ ca9f0e61-fc06-4a3c-9e2b-224b6aacf28c;FR;2025-07-06;2025-08-31;School;Regional;FR
 86d4d58b-76cf-4258-992c-ea51cac6b971;FR;2026-02-15;2026-03-01;School;Regional;FR Vacances d'hiver,DE Winterferien,EN Winter Holidays;CO
 717ae719-7db5-499c-a666-9bec72101f8f;FR;2026-04-12;2026-04-26;School;Regional;FR Vacances de printemps,DE Frühjahrsferien,EN Spring Holidays;CO
 34846635-8546-4a59-be73-5b2592d692ec;FR;2026-07-04;;EndOfLessons;Regional;FR Fin des cours,DE Unterrichtsende,EN End of lessons;CO
+fdb594f5-a904-4d41-a503-0119ca871f46;FR;2026-10-17;2026-11-02;School;Regional;FR Vacances de la Toussaint,DE Allerheiligenferien,EN All Saints Holidays;CO
+03cc28c5-037f-41bd-9d00-99d9f20a2cf6;FR;2026-12-19;2027-01-04;School;Regional;FR Vacances de Noël,DE Weihnachtsferien,EN Christmas Holidays;CO
+a61f16bb-cf89-4d75-8965-dcdfd8d210dd;FR;2027-02-13;2027-03-01;School;Regional;FR Vacances d'hiver,DE Winterferien,EN Winter Holidays;CO
+9842875b-ca08-4646-babc-f9ed2a2bbb2b;FR;2027-04-10;2027-04-26;School;Regional;FR Vacances de printemps,DE Frühjahrsferien,EN Spring Holidays;CO
+fa0e9a07-bda5-433f-88f2-933aae6c6225;FR;2027-07-03;;EndOfLessons;Regional;FR Fin des cours,DE Unterrichtsende,EN End of lessons;CO


### PR DESCRIPTION
## Summary

- Adds the 2026-2027 school holiday calendar for Corsica (CO) to src/fr/holidays/holidays.school.co.csv
- Covers: Vacances de la Toussaint, Vacances de Noël, Vacances d'hiver, Vacances de printemps, and end of lessons (start of summer break)

Source

Official French government school calendar 2026-2027, published by Service-Public.fr (Famille-Scolarité).

Dates added

```

┌─────────────────────┬────────────┬────────────┐
│       Period        │   Start    │    End     │
├─────────────────────┼────────────┼────────────┤
│ Toussaint           │ 2026-10-17 │ 2026-11-02 │
├─────────────────────┼────────────┼────────────┤
│ Noël                │ 2026-12-19 │ 2027-01-04 │
├─────────────────────┼────────────┼────────────┤
│ Hiver               │ 2027-02-13 │ 2027-03-01 │
├─────────────────────┼────────────┼────────────┤
│ Printemps           │ 2027-04-10 │ 2027-04-26 │
├─────────────────────┼────────────┼────────────┤
│ Fin des cours (été) │ 2027-07-03 │ —          │
└─────────────────────┴────────────┴────────────┘
```

Notes

Corsica has its own school calendar, independent of the mainland Zone A/B/C rotation, and is tracked in its dedicated file (holidays.school.co.csv), consistent with the other overseas/special-status territories (Guadeloupe, Martinique, Guyane, La Réunion, Saint-Pierre-et-Miquelon, Mayotte).